### PR TITLE
Forward port ignoring auth errors in Latest.

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -153,6 +153,9 @@ func (s *CharmStore) Latest(curls ...*charm.URL) ([]CharmRevision, error) {
 	// Prepare the request to the charm store.
 	urls := make([]string, len(curls))
 	values := url.Values{}
+	// Include the ignore-auth flag so that non-public results do not generate
+	// an error for the whole request.
+	values.Add("ignore-auth", "1")
 	values.Add("include", "id-revision")
 	values.Add("include", "hash256")
 	for i, curl := range curls {

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -99,8 +99,16 @@ func (s *charmStoreBaseSuite) addCharm(c *gc.C, urlStr, name string) (charm.Char
 		promulgatedRevision = id.Revision
 	}
 	ch := TestCharms.CharmArchive(c.MkDir(), name)
+
+	// Upload the charm.
 	err := s.client.UploadCharmWithRevision(id, ch, promulgatedRevision)
 	c.Assert(err, gc.IsNil)
+
+	// Allow read permissions to everyone.
+	err = s.client.Put("/"+id.Path()+"/meta/perm/read", []string{params.Everyone})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Return the charm and its URL.
 	url, err := id.URL("")
 	c.Assert(err, gc.IsNil)
 	return ch, url

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -367,8 +367,14 @@ func (s *charmStoreRepoSuite) TestLatest(c *gc.C) {
 	s.addCharm(c, "~dalek/trusty/riak-0", "riak")
 	s.addCharm(c, "~dalek/trusty/riak-1", "riak")
 	s.addCharm(c, "~dalek/trusty/riak-3", "riak")
+	_, url := s.addCharm(c, "~who/utopic/varnish-0", "varnish")
 
-	// Calculate and store the expected hashes for re uploaded charms.
+	// Change permissions on one of the charms so that it is not readable by
+	// anyone.
+	err := s.client.Put("/"+url.Path()+"/meta/perm/read", []string{"dalek"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Calculate and store the expected hashes for the uploaded charms.
 	mysqlHash := hashOfCharm(c, "mysql")
 	wordpressHash := hashOfCharm(c, "wordpress")
 	riakHash := hashOfCharm(c, "riak")
@@ -422,6 +428,18 @@ func (s *charmStoreRepoSuite) TestLatest(c *gc.C) {
 		}, {
 			Revision: 3,
 			Sha256:   riakHash,
+		}},
+	}, {
+		about: "unauthorized",
+		urls: []*charm.URL{
+			charm.MustParseURL("cs:~who/precise/wordpress"),
+			url,
+		},
+		revs: []charmrepo.CharmRevision{{
+			Revision: 1,
+			Sha256:   wordpressHash,
+		}, {
+			Err: charmrepo.CharmNotFound("cs:~who/utopic/varnish"),
 		}},
 	}}
 

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -107,7 +107,10 @@ func (s *suite) TestDefaultServerURL(c *gc.C) {
 	s.PatchValue(&csclient.ServerURL, s.srv.URL)
 
 	// Instantiate a client using the default server URL.
-	client := csclient.New(csclient.Params{})
+	client := csclient.New(csclient.Params{
+		User:     s.serverParams.AuthUsername,
+		Password: s.serverParams.AuthPassword,
+	})
 	c.Assert(client.ServerURL(), gc.Equals, s.srv.URL)
 
 	// Check that the request succeeds.
@@ -792,17 +795,18 @@ func (s *suite) TestDoAuthorization(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "invalid user name or password")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrUnauthorized)
 
-	// Check that it's still there.
-	err = client.Get("/~charmers/utopic/wordpress-42/expand-id", nil)
-	c.Assert(err, gc.IsNil)
-
-	// Then check that when we use the correct authorization,
-	// the delete succeeds.
 	client = csclient.New(csclient.Params{
 		URL:      s.srv.URL,
 		User:     s.serverParams.AuthUsername,
 		Password: s.serverParams.AuthPassword,
 	})
+
+	// Check that the charm is still there.
+	err = client.Get("/~charmers/utopic/wordpress-42/expand-id", nil)
+	c.Assert(err, gc.IsNil)
+
+	// Then check that when we use the correct authorization,
+	// the delete succeeds.
 	req, err = http.NewRequest("DELETE", "", nil)
 	c.Assert(err, gc.IsNil)
 	resp, err := client.Do(req, "/~charmers/utopic/wordpress-42/archive")

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -17,9 +17,9 @@ golang.org/x/crypto	git	4ed45ec682102c643324fae5dff8dab085b6c300	2015-01-12T22:0
 golang.org/x/net	git	7dbad50ab5b31073856416cdcfeb2796d682f844	2015-03-20T03:46:21Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
-gopkg.in/juju/charm.v5	git	4ce6225dae243c82f8a342749accaefbadad38e0	2015-04-10T08:52:37Z
+gopkg.in/juju/charm.v5	git	39463053128b672308c459958d00f260b58ce79e	2015-05-14T10:50:35Z
 gopkg.in/juju/charm.v6-unstable	git	69e524672748337e749acb16dbeefe3e80c946c0	2015-05-05T17:09:44Z
-gopkg.in/juju/charmstore.v4	git	777cd41439968b0e5d10492b7ad1492be29b50fc	2015-04-30T14:28:53Z
+gopkg.in/juju/charmstore.v4	git	3a87b423c3eeb105b82bba2f87d593d1b5763845	2015-05-14T14:17:49Z
 gopkg.in/macaroon-bakery.v0	git	9593b80b01ba04b519769d045dffd6abd827d2fd	2015-04-10T07:46:55Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	c6a7dce14133ccac2dcac3793f1d6e2ef048503a	2015-01-24T11:37:54Z


### PR DESCRIPTION
Also update to the last charm.v5 and charmstore.v4, and fix test errors due to default permissions changes.