### PR TITLE
csclient/params: add ErrServiceUnavailable

### DIFF
--- a/csclient/params/error.go
+++ b/csclient/params/error.go
@@ -25,10 +25,11 @@ const (
 	ErrForbidden        ErrorCode = "forbidden"
 	ErrBadRequest       ErrorCode = "bad request"
 	// TODO change to ErrAlreadyExists
-	ErrDuplicateUpload  ErrorCode = "duplicate upload"
-	ErrMultipleErrors   ErrorCode = "multiple errors"
-	ErrUnauthorized     ErrorCode = "unauthorized"
-	ErrMethodNotAllowed ErrorCode = "method not allowed"
+	ErrDuplicateUpload    ErrorCode = "duplicate upload"
+	ErrMultipleErrors     ErrorCode = "multiple errors"
+	ErrUnauthorized       ErrorCode = "unauthorized"
+	ErrMethodNotAllowed   ErrorCode = "method not allowed"
+	ErrServiceUnavailable ErrorCode = "service unavailable"
 
 	// Note that these error codes sit in the same name space
 	// as the bakery error codes defined in gopkg.in/macaroon-bakery.v0/httpbakery .


### PR DESCRIPTION
This will be returned as the error when a request cannot be satisfied
because there are too many concurrent requests.