### PR TITLE
Support retrieving bundles.

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -99,6 +99,10 @@ func (s *CharmStore) GetBundle(curl *charm.URL) (charm.Bundle, error) {
 	return charm.ReadBundleArchive(path)
 }
 
+// archivePath returns a local path to the downloaded archive of the given
+// charm or bundle URL, storing it in CacheDir, which it creates if necessary.
+// If an archive with a matching SHA hash already exists locally, it will use
+// the local version.
 func (s *CharmStore) archivePath(curl *charm.URL) (string, error) {
 	// Prepare the cache directory and retrieve the entity archive.
 	if err := os.MkdirAll(CacheDir, 0755); err != nil {

--- a/charmstore.go
+++ b/charmstore.go
@@ -17,8 +17,8 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0/csclient"
-	"gopkg.in/juju/charmrepo.v0/csclient/params"
+	"gopkg.in/juju/charmrepo.v1/csclient"
+	"gopkg.in/juju/charmrepo.v1/csclient/params"
 )
 
 // CacheDir stores the charm cache directory path.

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -20,6 +20,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmstore.v5-unstable"
 
@@ -319,7 +320,8 @@ func (s *charmStoreRepoSuite) TestGetErrorCacheDir(c *gc.C) {
 
 func (s *charmStoreRepoSuite) TestGetErrorCharmNotFound(c *gc.C) {
 	ch, err := s.repo.Get(charm.MustParseURL("cs:trusty/no-such"))
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:trusty/no-such": charm not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve "cs:trusty/no-such": charm not found`)
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 	c.Assert(ch, gc.IsNil)
 }
 

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -23,10 +23,10 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmstore.v5-unstable"
 
-	"gopkg.in/juju/charmrepo.v0"
-	"gopkg.in/juju/charmrepo.v0/csclient"
-	"gopkg.in/juju/charmrepo.v0/csclient/params"
-	charmtesting "gopkg.in/juju/charmrepo.v0/testing"
+	"gopkg.in/juju/charmrepo.v1"
+	"gopkg.in/juju/charmrepo.v1/csclient"
+	"gopkg.in/juju/charmrepo.v1/csclient/params"
+	charmtesting "gopkg.in/juju/charmrepo.v1/testing"
 )
 
 type charmStoreSuite struct {

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	"gopkg.in/juju/charmrepo.v0/csclient/params"
+	"gopkg.in/juju/charmrepo.v1/csclient/params"
 )
 
 const apiVersion = "v4"

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -30,9 +30,9 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/mgo.v2"
 
-	"gopkg.in/juju/charmrepo.v0/csclient"
-	"gopkg.in/juju/charmrepo.v0/csclient/params"
-	charmtesting "gopkg.in/juju/charmrepo.v0/testing"
+	"gopkg.in/juju/charmrepo.v1/csclient"
+	"gopkg.in/juju/charmrepo.v1/csclient/params"
+	charmtesting "gopkg.in/juju/charmrepo.v1/testing"
 )
 
 var charmRepo = charmtesting.NewRepo("../internal/test-charm-repo", "quantal")
@@ -1305,7 +1305,7 @@ func (s *suite) TestWhoAmI(c *gc.C) {
 		HTTPClient: httpClient,
 	})
 	response, err := client.WhoAmI()
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve whoami response: cannot get discharge from ".*": third party refused discharge: cannot discharge: no discharge`)
+	c.Assert(err, gc.ErrorMatches, `cannot get discharge from ".*": third party refused discharge: cannot discharge: no discharge`)
 	s.discharge = func(cond, arg string) ([]checkers.Caveat, error) {
 		return []checkers.Caveat{checkers.DeclaredCaveat("username", "bob")}, nil
 	}

--- a/csclient/params/params_test.go
+++ b/csclient/params/params_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
-	"gopkg.in/juju/charmrepo.v0/csclient/params"
+	"gopkg.in/juju/charmrepo.v1/csclient/params"
 )
 
 type suite struct{}

--- a/legacy.go
+++ b/legacy.go
@@ -346,6 +346,11 @@ func (s *LegacyCharmStore) Get(curl *charm.URL) (charm.Charm, error) {
 	return charm.ReadCharmArchive(path)
 }
 
+// GetBundle is only defined for implementing Interface.
+func (s *LegacyCharmStore) GetBundle(curl *charm.URL) (charm.Bundle, error) {
+	return nil, errors.New("not implemented: legacy API does not support bundles")
+}
+
 // LegacyInferRepository returns a charm repository inferred from the provided
 // charm or bundle reference. Local references will use the provided path.
 func LegacyInferRepository(ref *charm.Reference, localRepoPath string) (repo Interface, err error) {

--- a/legacy_test.go
+++ b/legacy_test.go
@@ -14,8 +14,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0"
-	charmtesting "gopkg.in/juju/charmrepo.v0/testing"
+	"gopkg.in/juju/charmrepo.v1"
+	charmtesting "gopkg.in/juju/charmrepo.v1/testing"
 )
 
 type legacyCharmStoreSuite struct {

--- a/local.go
+++ b/local.go
@@ -130,3 +130,9 @@ func (r *LocalRepository) Get(curl *charm.URL) (charm.Charm, error) {
 	}
 	return nil, charmNotFound(curl, r.Path)
 }
+
+// GetBundle implements Interface.GetBundle.
+func (r *LocalRepository) GetBundle(curl *charm.URL) (charm.Bundle, error) {
+	// TODO frankban: implement this.
+	return nil, errgo.New("not implemented yet")
+}

--- a/local_test.go
+++ b/local_test.go
@@ -13,7 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0"
+	"gopkg.in/juju/charmrepo.v1"
 )
 
 type LocalRepoSuite struct {

--- a/migratebundle/migrate_test.go
+++ b/migratebundle/migrate_test.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/yaml.v1"
 
-	"gopkg.in/juju/charmrepo.v0"
+	"gopkg.in/juju/charmrepo.v1"
 )
 
 var _ = gc.Suite(&migrateSuite{})

--- a/repo.go
+++ b/repo.go
@@ -19,6 +19,9 @@ type Interface interface {
 	// Get returns the charm referenced by curl.
 	Get(curl *charm.URL) (charm.Charm, error)
 
+	// GetBundle returns the bundle referenced by curl.
+	GetBundle(curl *charm.URL) (charm.Bundle, error)
+
 	// Latest returns the latest revision of the charms referenced by curls,
 	// regardless of the revision set on each curl.
 	Latest(curls ...*charm.URL) ([]CharmRevision, error)

--- a/repo_test.go
+++ b/repo_test.go
@@ -8,9 +8,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0"
-	"gopkg.in/juju/charmrepo.v0/csclient"
-	charmtesting "gopkg.in/juju/charmrepo.v0/testing"
+	"gopkg.in/juju/charmrepo.v1"
+	"gopkg.in/juju/charmrepo.v1/csclient"
+	charmtesting "gopkg.in/juju/charmrepo.v1/testing"
 )
 
 var TestCharms = charmtesting.NewRepo("internal/test-charm-repo", "quantal")

--- a/testing/charm.go
+++ b/testing/charm.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/utils/fs"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0"
+	"gopkg.in/juju/charmrepo.v1"
 )
 
 func check(err error) {

--- a/testing/charm.go
+++ b/testing/charm.go
@@ -8,12 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 
 	"github.com/juju/utils/fs"
 	"gopkg.in/juju/charm.v6-unstable"
-
-	"gopkg.in/juju/charmrepo.v1"
 )
 
 func check(err error) {
@@ -164,135 +161,4 @@ func (r *Repo) CharmArchive(dst, name string) *charm.CharmArchive {
 	ch, err := charm.ReadCharmArchive(r.CharmArchivePath(dst, name))
 	check(err)
 	return ch
-}
-
-// MockCharmStore implements charm/charmrepo.Interface and is used to isolate
-// tests that would otherwise need to hit the real charm store.
-type MockCharmStore struct {
-	charms map[string]map[int]*charm.CharmArchive
-
-	mu            sync.Mutex // protects the following fields
-	authAttrs     string
-	testMode      bool
-	defaultSeries string
-}
-
-func NewMockCharmStore() *MockCharmStore {
-	return &MockCharmStore{charms: map[string]map[int]*charm.CharmArchive{}}
-}
-
-// SetAuthAttrs overwrites the value returned by AuthAttrs
-func (s *MockCharmStore) SetAuthAttrs(auth string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.authAttrs = auth
-}
-
-// AuthAttrs returns the AuthAttrs for this charm store.
-func (s *MockCharmStore) AuthAttrs() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.authAttrs
-}
-
-// WithTestMode returns a repository Interface where testMode is set to value
-// passed to this method.
-func (s *MockCharmStore) WithTestMode(testMode bool) charmrepo.Interface {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.testMode = testMode
-	return s
-}
-
-// TestMode returns the test mode setting of this charm store.
-func (s *MockCharmStore) TestMode() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.testMode
-}
-
-// SetDefaultSeries overwrites the default series for this charm store.
-func (s *MockCharmStore) SetDefaultSeries(series string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.defaultSeries = series
-}
-
-// DefaultSeries returns the default series for this charm store.
-func (s *MockCharmStore) DefaultSeries() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.defaultSeries
-}
-
-// Resolve implements charm/charmrepo.Interface.Resolve.
-func (s *MockCharmStore) Resolve(ref *charm.Reference) (*charm.URL, error) {
-	return ref.URL(s.DefaultSeries())
-}
-
-// SetCharm adds and removes charms in s. The affected charm is identified by
-// charmURL, which must be revisioned. If archive is nil, the charm will be
-// removed; otherwise, it will be stored. It is an error to store a archive
-// under a charmURL that does not share its name and revision.
-func (s *MockCharmStore) SetCharm(charmURL *charm.URL, archive *charm.CharmArchive) error {
-	base := charmURL.WithRevision(-1).String()
-	if charmURL.Revision < 0 {
-		return fmt.Errorf("bad charm url revision")
-	}
-	if archive == nil {
-		delete(s.charms[base], charmURL.Revision)
-		return nil
-	}
-	archiveRev := archive.Revision()
-	archiveName := archive.Meta().Name
-	if archiveName != charmURL.Name || archiveRev != charmURL.Revision {
-		return fmt.Errorf("charm url %s mismatch with archive %s-%d", charmURL, archiveName, archiveRev)
-	}
-	if _, found := s.charms[base]; !found {
-		s.charms[base] = map[int]*charm.CharmArchive{}
-	}
-	s.charms[base][charmURL.Revision] = archive
-	return nil
-}
-
-// interpret extracts from charmURL information relevant to both Latest and
-// Get. The returned "base" is always the string representation of the
-// unrevisioned part of charmURL; the "rev" wil be taken from the charmURL if
-// available, and will otherwise be the revision of the latest charm in the
-// store with the same "base".
-func (s *MockCharmStore) interpret(charmURL *charm.URL) (base string, rev int) {
-	base, rev = charmURL.WithRevision(-1).String(), charmURL.Revision
-	if rev == -1 {
-		for candidate := range s.charms[base] {
-			if candidate > rev {
-				rev = candidate
-			}
-		}
-	}
-	return
-}
-
-// Get implements charm/charmrepo.Interface.Get.
-func (s *MockCharmStore) Get(charmURL *charm.URL) (charm.Charm, error) {
-	base, rev := s.interpret(charmURL)
-	charm, found := s.charms[base][rev]
-	if !found {
-		return nil, fmt.Errorf("charm not found in mock store: %s", charmURL)
-	}
-	return charm, nil
-}
-
-// Latest implements charm/charmrepo.Interface.Latest.
-func (s *MockCharmStore) Latest(charmURLs ...*charm.URL) ([]charmrepo.CharmRevision, error) {
-	result := make([]charmrepo.CharmRevision, len(charmURLs))
-	for i, curl := range charmURLs {
-		charmURL := curl.WithRevision(-1)
-		base, rev := s.interpret(charmURL)
-		if _, found := s.charms[base][rev]; !found {
-			result[i].Err = fmt.Errorf("charm not found in mock store: %s", charmURL)
-		} else {
-			result[i].Revision = rev
-		}
-	}
-	return result, nil
 }

--- a/testing/charm.go
+++ b/testing/charm.go
@@ -162,3 +162,12 @@ func (r *Repo) CharmArchive(dst, name string) *charm.CharmArchive {
 	check(err)
 	return ch
 }
+
+// BundleArchive returns an actual charm.BundleArchive created from a new
+// bundle archive file created from the bundle directory named name, in
+// the directory dst.
+func (r *Repo) BundleArchive(dst, name string) *charm.BundleArchive {
+	b, err := charm.ReadBundleArchive(r.BundleArchivePath(dst, name))
+	check(err)
+	return b
+}

--- a/testing/mockstore.go
+++ b/testing/mockstore.go
@@ -18,7 +18,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0"
+	"gopkg.in/juju/charmrepo.v1"
 )
 
 var logger = loggo.GetLogger("juju.charm.testing.mockstore")

--- a/testing/testcharm_test.go
+++ b/testing/testcharm_test.go
@@ -6,7 +6,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 
-	"gopkg.in/juju/charmrepo.v0/testing"
+	"gopkg.in/juju/charmrepo.v1/testing"
 )
 
 var _ = gc.Suite(&testCharmSuite{})


### PR DESCRIPTION
Switch to charmrepo.v1.
Extend Interface to include a method for retrieving bundles.
Also remove the deprecated MockCharmStore and other small clean up.