### PR TITLE
Propagate error causes when retrieving charms and bundles.

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -78,7 +78,7 @@ func (s *CharmStore) Get(curl *charm.URL) (charm.Charm, error) {
 	}
 	path, err := s.archivePath(curl)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
+		return nil, errgo.Mask(err, errgo.Any)
 	}
 	return charm.ReadCharmArchive(path)
 }
@@ -94,7 +94,7 @@ func (s *CharmStore) GetBundle(curl *charm.URL) (charm.Bundle, error) {
 	}
 	path, err := s.archivePath(curl)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
+		return nil, errgo.Mask(err, errgo.Any)
 	}
 	return charm.ReadBundleArchive(path)
 }

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -363,6 +363,7 @@ func (s *charmStoreRepoSuite) TestGetErrorServer(c *gc.C) {
 	})
 	ch, err := repo.Get(charm.MustParseURL("cs:trusty/django"))
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve charm "cs:trusty/django": cannot get archive: bad wolf`)
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrBadRequest)
 	c.Assert(ch, gc.IsNil)
 }
 


### PR DESCRIPTION
Also update a test so that future regressions can be avoided.