### PR TITLE
Update dependencies and fix some tests for mongo without js

### DIFF
--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -261,6 +261,9 @@ func (s *charmStoreRepoSuite) TestGetInvalidCache(c *gc.C) {
 }
 
 func (s *charmStoreRepoSuite) TestGetIncreaseStats(c *gc.C) {
+	if jujutesting.MgoServer.WithoutV8 {
+		c.Skip("mongo javascript not enabled")
+	}
 	_, url := s.addCharm(c, "~who/precise/wordpress-2", "wordpress")
 
 	// Retrieve the charm.

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -290,6 +290,9 @@ func (s *suite) TestPutSuccess(c *gc.C) {
 }
 
 func (s *suite) TestGetArchive(c *gc.C) {
+	if jujutesting.MgoServer.WithoutV8 {
+		c.Skip("mongo javascript not enabled")
+	}
 	key := s.checkGetArchive(c)
 
 	// Check that the downloads count for the entity has been updated.
@@ -305,13 +308,16 @@ func (s *suite) TestGetArchiveWithStatsDisabled(c *gc.C) {
 }
 
 func (s *suite) TestStatsUpdate(c *gc.C) {
+	if jujutesting.MgoServer.WithoutV8 {
+		c.Skip("mongo javascript not enabled")
+	}
 	key := s.checkGetArchive(c)
 	s.checkCharmDownloads(c, key, 1)
-	err := s.client.StatsUpdate(params.StatsUpdateRequest {
+	err := s.client.StatsUpdate(params.StatsUpdateRequest{
 		Entries: []params.StatsUpdateEntry{{
 			CharmReference: charm.MustParseReference("~charmers/utopic/wordpress-42"),
-			Timestamp: time.Now(),
-			Type: params.UpdateDeploy,
+			Timestamp:      time.Now(),
+			Type:           params.UpdateDeploy,
 		}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -428,7 +434,7 @@ var getArchiveWithBadResponseTests = []struct {
 		Body:          ioutil.NopCloser(strings.NewReader("")),
 		ContentLength: fakeSize,
 	},
-	expectError: `invalid entity id found in response: charm URL has invalid schema: "no:such"`,
+	expectError: `invalid entity id found in response: charm or bundle URL has invalid schema: "no:such"`,
 }, {
 	about: "partial entity id header",
 	response: &http.Response{

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -16,7 +16,8 @@ golang.org/x/crypto	git	1e856cbfdf9bc25eefca75f83f25d55e35ae72e0	2015-06-08T19:5
 golang.org/x/net	git	38f3db3860bb1812858610029b0d8188517d8b74	2015-06-22T06:16:26Z
 gopkg.in/check.v1	git	8d49746f13e4c654088c52685541fcf4cbc8fa59	2015-06-10T23:30:30Z
 gopkg.in/errgo.v1	git	15098963088579c1cd9eb1a7da285831e548390b	2015-07-07T18:34:45Z
-gopkg.in/juju/charm.v6-unstable	git	f2045cd59d58471fbfd0b799e2e13eae232280a4	2015-06-18T15:58:44Z
+gopkg.in/juju/charm.v6-unstable	git	3c02d70668d5150161700fd53fd362207cfe542e	2015-09-28T09:23:11Z
+gopkg.in/juju/charmrepo.v1	git	8677b12d9772a2a596a99e65b7e6f642fceb6c40	2015-09-14T13:26:00Z
 gopkg.in/juju/charmstore.v5-unstable	git	a921c6c69d74361c38a99a95d2aceec76533038d	2015-08-27T20:19:40Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
 gopkg.in/macaroon-bakery.v1	git	bdee217a76810b6987880e3edfc45ec3f575a915	2015-07-21T11:40:50Z


### PR DESCRIPTION
Use charm.v6-unstable with supported-series
Fix a test
Skip mongo tests which use js if no js