### PR TITLE
Reject charms and bundles specified with relative paths

### DIFF
--- a/bundlepath.go
+++ b/bundlepath.go
@@ -17,9 +17,12 @@ func NewBundleAtPath(path string) (charm.Bundle, *charm.URL, error) {
 	if path == "" {
 		return nil, nil, errgo.New("path to bundle not specified")
 	}
-	_, err := os.Stat(path)
+	fi, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil, os.ErrNotExist
+	}
+	if !mightBeCharmOrBundlePath(path, fi) {
+		return nil, nil, InvalidPath(path)
 	}
 	b, err := charm.ReadBundle(path)
 	if err != nil {

--- a/bundlepath.go
+++ b/bundlepath.go
@@ -17,12 +17,12 @@ func NewBundleAtPath(path string) (charm.Bundle, *charm.URL, error) {
 	if path == "" {
 		return nil, nil, errgo.New("path to bundle not specified")
 	}
-	fi, err := os.Stat(path)
+	if !isValidCharmOrBundlePath(path) {
+		return nil, nil, InvalidPath(path)
+	}
+	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil, os.ErrNotExist
-	}
-	if !mightBeCharmOrBundlePath(path, fi) {
-		return nil, nil, InvalidPath(path)
 	}
 	b, err := charm.ReadBundle(path)
 	if err != nil {

--- a/bundlepath_test.go
+++ b/bundlepath_test.go
@@ -34,7 +34,7 @@ func (s *bundlePathSuite) TestNoPath(c *gc.C) {
 }
 
 func (s *bundlePathSuite) TestInvalidPath(c *gc.C) {
-	_, _, err := charmrepo.NewBundleAtPath("foo")
+	_, _, err := charmrepo.NewBundleAtPath("./foo")
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }
 

--- a/bundlepath_test.go
+++ b/bundlepath_test.go
@@ -43,7 +43,7 @@ func (s *bundlePathSuite) TestRelativePath(c *gc.C) {
 	cwd, err := os.Getwd()
 	c.Assert(err, jc.ErrorIsNil)
 	defer os.Chdir(cwd)
-	os.Chdir(relDir)
+	c.Assert(os.Chdir(relDir), jc.ErrorIsNil)
 	_, _, err = charmrepo.NewBundleAtPath("openstack")
 	c.Assert(charmrepo.IsInvalidPathError(err), jc.IsTrue)
 }

--- a/bundlepath_test.go
+++ b/bundlepath_test.go
@@ -38,6 +38,16 @@ func (s *bundlePathSuite) TestInvalidPath(c *gc.C) {
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }
 
+func (s *bundlePathSuite) TestRelativePath(c *gc.C) {
+	relDir := filepath.Join(TestCharms.Path(), "bundle")
+	cwd, err := os.Getwd()
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Chdir(cwd)
+	os.Chdir(relDir)
+	_, _, err = charmrepo.NewBundleAtPath("openstack")
+	c.Assert(charmrepo.IsInvalidPathError(err), jc.IsTrue)
+}
+
 func (s *bundlePathSuite) TestNoBundleAtPath(c *gc.C) {
 	_, _, err := charmrepo.NewBundleAtPath(c.MkDir())
 	c.Assert(err, gc.ErrorMatches, `no bundle found at ".*"`)

--- a/charmpath.go
+++ b/charmpath.go
@@ -12,10 +12,7 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 )
 
-func mightBeCharmOrBundlePath(path string, info os.FileInfo) bool {
-	if !info.IsDir() {
-		return false
-	}
+func isValidCharmOrBundlePath(path string) bool {
 	//Exclude relative paths.
 	return strings.HasPrefix(path, ".") || filepath.IsAbs(path)
 }
@@ -29,12 +26,12 @@ func NewCharmAtPath(path, series string) (charm.Charm, *charm.URL, error) {
 	if path == "" {
 		return nil, nil, errgo.New("empty charm path")
 	}
-	fi, err := os.Stat(path)
+	if !isValidCharmOrBundlePath(path) {
+		return nil, nil, InvalidPath(path)
+	}
+	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil, os.ErrNotExist
-	}
-	if !mightBeCharmOrBundlePath(path, fi) {
-		return nil, nil, InvalidPath(path)
 	}
 	ch, err := charm.ReadCharm(path)
 	if err != nil {

--- a/charmpath.go
+++ b/charmpath.go
@@ -17,7 +17,7 @@ func mightBeCharmOrBundlePath(path string, info os.FileInfo) bool {
 		return false
 	}
 	//Exclude relative paths.
-	return strings.HasPrefix(path, ".") || strings.HasPrefix(path, string(filepath.Separator))
+	return strings.HasPrefix(path, ".") || filepath.IsAbs(path)
 }
 
 // NewCharmAtPath returns the charm represented by this path,

--- a/charmpath_test.go
+++ b/charmpath_test.go
@@ -34,7 +34,7 @@ func (s *charmPathSuite) TestNoPath(c *gc.C) {
 }
 
 func (s *charmPathSuite) TestInvalidPath(c *gc.C) {
-	_, _, err := charmrepo.NewCharmAtPath("foo", "trusty")
+	_, _, err := charmrepo.NewCharmAtPath("./foo", "trusty")
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }
 

--- a/charmpath_test.go
+++ b/charmpath_test.go
@@ -38,6 +38,16 @@ func (s *charmPathSuite) TestInvalidPath(c *gc.C) {
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }
 
+func (s *charmPathSuite) TestRelativePath(c *gc.C) {
+	s.cloneCharmDir(s.repoPath, "mysql")
+	cwd, err := os.Getwd()
+	c.Assert(err, jc.ErrorIsNil)
+	defer os.Chdir(cwd)
+	os.Chdir(s.repoPath)
+	_, _, err = charmrepo.NewCharmAtPath("mysql", "trusty")
+	c.Assert(charmrepo.IsInvalidPathError(err), jc.IsTrue)
+}
+
 func (s *charmPathSuite) TestNoCharmAtPath(c *gc.C) {
 	_, _, err := charmrepo.NewCharmAtPath(c.MkDir(), "trusty")
 	c.Assert(err, gc.ErrorMatches, "charm not found.*")

--- a/charmpath_test.go
+++ b/charmpath_test.go
@@ -43,7 +43,7 @@ func (s *charmPathSuite) TestRelativePath(c *gc.C) {
 	cwd, err := os.Getwd()
 	c.Assert(err, jc.ErrorIsNil)
 	defer os.Chdir(cwd)
-	os.Chdir(s.repoPath)
+	c.Assert(os.Chdir(s.repoPath), jc.ErrorIsNil)
 	_, _, err = charmrepo.NewCharmAtPath("mysql", "trusty")
 	c.Assert(charmrepo.IsInvalidPathError(err), jc.IsTrue)
 }

--- a/params.go
+++ b/params.go
@@ -59,3 +59,23 @@ func CharmNotFound(url string) error {
 		msg: "charm not found: " + url,
 	}
 }
+
+// InvalidPath returns an invalidPathError.
+func InvalidPath(path string) error {
+	return &invalidPathError{path}
+}
+
+// invalidPathError represents an error indicating that the requested
+// charm or bundle path is not valid as a charm or bundle path.
+type invalidPathError struct {
+	path string
+}
+
+func (e *invalidPathError) Error() string {
+	return fmt.Sprintf("path %q can not be a relative path", e.path)
+}
+
+func IsInvalidPathError(err error) bool {
+	_, ok := err.(*invalidPathError)
+	return ok
+}


### PR DESCRIPTION
NewCharmAtPath and NewBundleAtPath reject relative paths even if they are otherwise valid paths.
We want to avoid ambiguity.