### PR TITLE
Bundle notfound error

### DIFF
--- a/bundlepath.go
+++ b/bundlepath.go
@@ -27,7 +27,7 @@ func NewBundleAtPath(path string) (charm.Bundle, *charm.URL, error) {
 	b, err := charm.ReadBundle(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil, errgo.Newf("no bundle found at %q", path)
+			return nil, nil, BundleNotFound(path)
 		}
 		return nil, nil, err
 	}

--- a/bundlepath.go
+++ b/bundlepath.go
@@ -17,12 +17,12 @@ func NewBundleAtPath(path string) (charm.Bundle, *charm.URL, error) {
 	if path == "" {
 		return nil, nil, errgo.New("path to bundle not specified")
 	}
-	if !isValidCharmOrBundlePath(path) {
-		return nil, nil, InvalidPath(path)
-	}
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil, os.ErrNotExist
+	}
+	if !isValidCharmOrBundlePath(path) {
+		return nil, nil, InvalidPath(path)
 	}
 	b, err := charm.ReadBundle(path)
 	if err != nil {

--- a/bundlepath_test.go
+++ b/bundlepath_test.go
@@ -50,7 +50,7 @@ func (s *bundlePathSuite) TestRelativePath(c *gc.C) {
 
 func (s *bundlePathSuite) TestNoBundleAtPath(c *gc.C) {
 	_, _, err := charmrepo.NewBundleAtPath(c.MkDir())
-	c.Assert(err, gc.ErrorMatches, `no bundle found at ".*"`)
+	c.Assert(err, gc.ErrorMatches, `bundle not found:.*`)
 }
 
 func (s *bundlePathSuite) TestGetBundle(c *gc.C) {

--- a/bundlepath_test.go
+++ b/bundlepath_test.go
@@ -34,6 +34,11 @@ func (s *bundlePathSuite) TestNoPath(c *gc.C) {
 }
 
 func (s *bundlePathSuite) TestInvalidPath(c *gc.C) {
+	_, _, err := charmrepo.NewBundleAtPath("/foo")
+	c.Assert(err, gc.Equals, os.ErrNotExist)
+}
+
+func (s *bundlePathSuite) TestInvalidRelativePath(c *gc.C) {
 	_, _, err := charmrepo.NewBundleAtPath("./foo")
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }

--- a/charmpath.go
+++ b/charmpath.go
@@ -26,12 +26,12 @@ func NewCharmAtPath(path, series string) (charm.Charm, *charm.URL, error) {
 	if path == "" {
 		return nil, nil, errgo.New("empty charm path")
 	}
-	if !isValidCharmOrBundlePath(path) {
-		return nil, nil, InvalidPath(path)
-	}
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil, os.ErrNotExist
+	}
+	if !isValidCharmOrBundlePath(path) {
+		return nil, nil, InvalidPath(path)
 	}
 	ch, err := charm.ReadCharm(path)
 	if err != nil {

--- a/charmpath_test.go
+++ b/charmpath_test.go
@@ -34,6 +34,11 @@ func (s *charmPathSuite) TestNoPath(c *gc.C) {
 }
 
 func (s *charmPathSuite) TestInvalidPath(c *gc.C) {
+	_, _, err := charmrepo.NewCharmAtPath("/foo", "trusty")
+	c.Assert(err, gc.Equals, os.ErrNotExist)
+}
+
+func (s *charmPathSuite) TestInvalidRelativePath(c *gc.C) {
 	_, _, err := charmrepo.NewCharmAtPath("./foo", "trusty")
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }

--- a/params.go
+++ b/params.go
@@ -54,7 +54,7 @@ func entityNotFound(curl *charm.URL, repoPath string) error {
 	return &NotFoundError{fmt.Sprintf("entity not found in %q: %s", repoPath, curl)}
 }
 
-// CharmNotFound represents an error indicating that the
+// CharmNotFound returns an error indicating that the
 // charm at the specified URL does not exist. 
 func CharmNotFound(url string) error {
 	return &NotFoundError{
@@ -62,7 +62,7 @@ func CharmNotFound(url string) error {
 	}
 }
 
-// BundleNotFound represents an error indicating that the
+// BundleNotFound returns an error indicating that the
 // bundle at the specified URL does not exist. 
 func BundleNotFound(url string) error {
 	return &NotFoundError{

--- a/params.go
+++ b/params.go
@@ -54,12 +54,16 @@ func entityNotFound(curl *charm.URL, repoPath string) error {
 	return &NotFoundError{fmt.Sprintf("entity not found in %q: %s", repoPath, curl)}
 }
 
+// CharmNotFound represents an error indicating that the
+// charm at the specified URL does not exist. 
 func CharmNotFound(url string) error {
 	return &NotFoundError{
 		msg: "charm not found: " + url,
 	}
 }
 
+// BundleNotFound represents an error indicating that the
+// bundle at the specified URL does not exist. 
 func BundleNotFound(url string) error {
 	return &NotFoundError{
 		msg: "bundle not found: " + url,

--- a/params.go
+++ b/params.go
@@ -60,6 +60,12 @@ func CharmNotFound(url string) error {
 	}
 }
 
+func BundleNotFound(url string) error {
+	return &NotFoundError{
+		msg: "bundle not found: " + url,
+	}
+}
+
 // InvalidPath returns an invalidPathError.
 func InvalidPath(path string) error {
 	return &invalidPathError{path}


### PR DESCRIPTION
Add a new BundleNotFound error to match what is done for charms.
Also, when loading  a charm or bundle from a path, check that a supplied path exists before testing if it is relative or not.