### PR TITLE
001 legacy no escape v2 unstable

### DIFF
--- a/csclient/params/stats.go
+++ b/csclient/params/stats.go
@@ -5,10 +5,11 @@ package params
 
 // Define the kinds to be included in stats keys.
 const (
-	StatsArchiveDownload     = "archive-download"
-	StatsArchiveDelete       = "archive-delete"
-	StatsArchiveFailedUpload = "archive-failed-upload"
-	StatsArchiveUpload       = "archive-upload"
+	StatsArchiveDownload            = "archive-download"
+	StatsArchiveDownloadPromulgated = "archive-download-promulgated"
+	StatsArchiveDelete              = "archive-delete"
+	StatsArchiveFailedUpload        = "archive-failed-upload"
+	StatsArchiveUpload              = "archive-upload"
 	// The following kinds are in use in the legacy API.
 	StatsCharmInfo    = "charm-info"
 	StatsCharmMissing = "charm-missing"

--- a/legacy.go
+++ b/legacy.go
@@ -315,7 +315,7 @@ func (s *LegacyCharmStore) Get(curl *charm.URL) (charm.Charm, error) {
 	}
 	path := filepath.Join(CacheDir, charm.Quote(curl.String())+".charm")
 	if verify(path, digest) != nil {
-		store_url := s.BaseURL + "/charm/" + url.QueryEscape(curl.Path())
+		store_url := s.BaseURL + "/charm/" + curl.Path()
 		if s.testMode {
 			store_url = store_url + "?stats=0"
 		}
@@ -324,6 +324,9 @@ func (s *LegacyCharmStore) Get(curl *charm.URL) (charm.Charm, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("bad status from request for %q: %q", store_url, resp.Status)
+		}
 		f, err := ioutil.TempFile(CacheDir, "charm-download")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is identical to https://github.com/juju/charmrepo/pull/38 but targeted at the unstable branch.