### PR TITLE
csclient/params: add SupportedSeries response type

### DIFF
--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -123,6 +123,12 @@ type RevisionInfoResponse struct {
 	Revisions []*charm.Reference
 }
 
+// SupportedSeries holds the result of an id/meta/supported-series GET
+// request. See See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetasupported-series
+type SupportedSeriesResponse struct {
+	SupportedSeries []string
+}
+
 // BundleCount holds the result of an id/meta/bundle-unit-count
 // or bundle-machine-count GET request.
 // See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundle-unit-count


### PR DESCRIPTION
The endpoint that this pertains to will be this:

#### GET *id*/meta/supported-series

This path returns the set of series supported by the given
charm. This endpoint is appropriate for charms only.

```go
type SupportedSeriesResponse struct {
    SupportedSeries []string
}
```

Example: `GET precise/wordpress/meta/supported-series`

Response body:
```json
{
    "SupportedSeries": ["precise"]
}
```
