### PR TITLE
Handle path not exists errors on Windows

### DIFF
--- a/bundlepath.go
+++ b/bundlepath.go
@@ -18,15 +18,14 @@ func NewBundleAtPath(path string) (charm.Bundle, *charm.URL, error) {
 		return nil, nil, errgo.New("path to bundle not specified")
 	}
 	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if isNotExistsError(err) {
 		return nil, nil, os.ErrNotExist
-	}
-	if !isValidCharmOrBundlePath(path) {
+	} else if err == nil && !isValidCharmOrBundlePath(path) {
 		return nil, nil, InvalidPath(path)
 	}
 	b, err := charm.ReadBundle(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if isNotExistsError(err) {
 			return nil, nil, BundleNotFound(path)
 		}
 		return nil, nil, err
@@ -50,7 +49,7 @@ func NewBundleAtPath(path string) (charm.Bundle, *charm.URL, error) {
 func ReadBundleFile(path string) (*charm.BundleData, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if isNotExistsError(err) {
 			return nil, BundleNotFound(path)
 		}
 		return nil, err

--- a/bundlepath_test.go
+++ b/bundlepath_test.go
@@ -40,6 +40,11 @@ func (s *bundlePathSuite) TestInvalidPath(c *gc.C) {
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }
 
+func (s *bundlePathSuite) TestRepoURL(c *gc.C) {
+	_, _, err := charmrepo.NewCharmAtPath("cs:foo", "trusty")
+	c.Assert(err, gc.Equals, os.ErrNotExist)
+}
+
 func (s *bundlePathSuite) TestInvalidRelativePath(c *gc.C) {
 	_, _, err := charmrepo.NewBundleAtPath("./foo")
 	c.Assert(err, gc.Equals, os.ErrNotExist)

--- a/charmpath_test.go
+++ b/charmpath_test.go
@@ -38,6 +38,11 @@ func (s *charmPathSuite) TestInvalidPath(c *gc.C) {
 	c.Assert(err, gc.Equals, os.ErrNotExist)
 }
 
+func (s *charmPathSuite) TestRepoURL(c *gc.C) {
+	_, _, err := charmrepo.NewCharmAtPath("cs:foo", "trusty")
+	c.Assert(err, gc.Equals, os.ErrNotExist)
+}
+
 func (s *charmPathSuite) TestInvalidRelativePath(c *gc.C) {
 	_, _, err := charmrepo.NewCharmAtPath("./foo", "trusty")
 	c.Assert(err, gc.Equals, os.ErrNotExist)

--- a/local.go
+++ b/local.go
@@ -156,7 +156,7 @@ func (r *LocalRepository) checkUrlAndPath(curl *charm.URL) error {
 	}
 	info, err := os.Stat(r.Path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if isNotExistsError(err) {
 			return repoNotFound(r.Path)
 		}
 		return err


### PR DESCRIPTION
On Windows, a call to os.Stat doesn't return a error satisfying os.IsNotExist when the file/path isn't there. It returns a os.PathError with a message like "GetFileAttributesEx.*: The system cannot find the (file|path) specified." So we introduce a helper function and make sure we handle both Windows and non Windows cases.