### PR TITLE
update charmstore dependency to mainline version

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	7a350e31b7caa6588ba0448627fd760bf805c927	2015-11-12T17:59:38Z
-gopkg.in/juju/charmstore.v5-unstable	git	a49590ad3b483444547d8a34a1629ddc44e61859	2015-11-13T10:52:22Z
+gopkg.in/juju/charmstore.v5-unstable	git	e640e9e7a508b99bd6d1e2cf44b77925c4467c68	2015-11-13T11:28:12Z
 gopkg.in/juju/jujusvg.v1	git	af9eeac59c8724a359206dfd987b42242999fbd6	2015-11-12T18:48:11Z
 gopkg.in/macaroon-bakery.v1	git	e569eb58bf9977eb8a1f20d405535d45c66035be	2015-10-22T13:30:53Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
Because of the cyclic dependency, the previous dependency was
on a temporary branch.
