### PR TITLE
csclient: use v5 API

### DIFF
--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -80,7 +80,7 @@ func (s *charmStoreBaseSuite) startServer(c *gc.C) {
 	}
 
 	db := s.Session.DB("charmstore")
-	handler, err := charmstore.NewServer(db, nil, "", serverParams, charmstore.V4)
+	handler, err := charmstore.NewServer(db, nil, "", serverParams, charmstore.V5)
 	c.Assert(err, gc.IsNil)
 	s.handler = handler
 	s.srv = httptest.NewServer(handler)

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 )
 
-const apiVersion = "v4"
+const apiVersion = "v5"
 
 // ServerURL holds the default location of the global charm store.
 // An alternate location can be configured by changing the URL field in the

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -89,7 +89,7 @@ func (s *suite) startServer(c *gc.C, session *mgo.Session) {
 	}
 
 	db := session.DB("charmstore")
-	handler, err := charmstore.NewServer(db, nil, "", serverParams, charmstore.V4)
+	handler, err := charmstore.NewServer(db, nil, "", serverParams, charmstore.V5)
 	c.Assert(err, gc.IsNil)
 	s.handler = handler
 	s.srv = httptest.NewServer(handler)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
-gopkg.in/juju/charmstore.v5-unstable	git	e3e4f7b9e2b930e84db3e21c44853a43f38d4c50	2015-11-30T13:47:17Z
+gopkg.in/juju/charmstore.v5-unstable	git	ab265b218958b7b5ec23f7ec2320a4c2af7edfb6	2016-01-08T15:51:05Z
 gopkg.in/juju/jujusvg.v1	git	2c97ff517dee12dc48bb3c2d2b113e5045a75b71	2015-11-19T14:54:17Z
 gopkg.in/macaroon-bakery.v1	git	e569eb58bf9977eb8a1f20d405535d45c66035be	2015-10-22T13:30:53Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
The old tests failed against the charmstore v4 API
(because it has compatibility for v4),
and we shouldn't really have been testing
multi-series charms against the new API anyway.
