### PR TITLE
csclient/params: use EntityResult in RelatedResponse

### DIFF
--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -33,10 +33,7 @@ const (
 
 // MetaAnyResponse holds the result of a meta/any request.
 // See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaany
-type MetaAnyResponse struct {
-	Id   *charm.URL
-	Meta map[string]interface{} `json:",omitempty"`
-}
+type MetaAnyResponse EntityResult
 
 // ArchiveUploadResponse holds the result of a post or a put to /id/archive.
 // See https://github.com/juju/charmstore/blob/v4/docs/API.md#post-idarchive
@@ -110,11 +107,11 @@ type ArchiveUploadTimeResponse struct {
 type RelatedResponse struct {
 	// Requires holds an entry for each interface provided by
 	// the charm, containing all charms that require that interface.
-	Requires map[string][]MetaAnyResponse `json:",omitempty"`
+	Requires map[string][]EntityResult `json:",omitempty"`
 
 	// Provides holds an entry for each interface required by the
 	// the charm, containing all charms that provide that interface.
-	Provides map[string][]MetaAnyResponse `json:",omitempty"`
+	Provides map[string][]EntityResult `json:",omitempty"`
 }
 
 // RevisionInfoResponse holds the result of an id/meta/revision-info GET

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
-gopkg.in/juju/charmstore.v5-unstable	git	ab265b218958b7b5ec23f7ec2320a4c2af7edfb6	2016-01-08T15:51:05Z
+gopkg.in/juju/charmstore.v5-unstable	git	502b8a627a5765b4f41a3c59a7d1e5b633f8dfdf	2016-01-11T13:27:05Z
 gopkg.in/juju/jujusvg.v1	git	2c97ff517dee12dc48bb3c2d2b113e5045a75b71	2015-11-19T14:54:17Z
 gopkg.in/macaroon-bakery.v1	git	e569eb58bf9977eb8a1f20d405535d45c66035be	2015-10-22T13:30:53Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
This unifies the entities returned by charm-related with those returned
by other "list-style" endpoints such as /list and /search. MetaAnyResponse
was always wrong here, as the *Response names should be reserved
for responses to individual endpoints.

Technically this is a backwardly incompatible package change (no
change to the HTTP API) so it should cause us to change the charmrepo
version. I'm minded to forget about it because we have no known
client programs that use params.RelatedResponse and submit this
as is.

I'm very willing to accept arguments to the contrary though.
