### PR TITLE
add import comments

### DIFF
--- a/bundlepath.go
+++ b/bundlepath.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"os"

--- a/charmpath.go
+++ b/charmpath.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"os"

--- a/charmstore.go
+++ b/charmstore.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"crypto/sha512"

--- a/csclient/archive.go
+++ b/csclient/archive.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package csclient
+package csclient // import "gopkg.in/juju/charmrepo.v2-unstable/csclient"
 
 import (
 	"crypto/sha512"

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -2,7 +2,7 @@
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 // The csclient package provides access to the charm store API.
-package csclient
+package csclient // import "gopkg.in/juju/charmrepo.v2-unstable/csclient"
 
 import (
 	"bytes"

--- a/csclient/params/error.go
+++ b/csclient/params/error.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package params
+package params // import "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 import (
 	"fmt"

--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -4,7 +4,7 @@
 // The params package holds types that are a part of the charm store's external
 // contract - they will be marshalled (or unmarshalled) as JSON
 // and delivered through the HTTP API.
-package params
+package params // import "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 import (
 	"encoding/json"

--- a/csclient/params/stats.go
+++ b/csclient/params/stats.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package params
+package params // import "gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 // Define the kinds to be included in stats keys.
 const (

--- a/legacy.go
+++ b/legacy.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"encoding/json"

--- a/local.go
+++ b/local.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"fmt"

--- a/migratebundle/migrate.go
+++ b/migratebundle/migrate.go
@@ -1,4 +1,4 @@
-package migratebundle
+package migratebundle // import "gopkg.in/juju/charmrepo.v2-unstable/migratebundle"
 
 import (
 	"fmt"

--- a/params.go
+++ b/params.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"fmt"

--- a/repo.go
+++ b/repo.go
@@ -3,7 +3,7 @@
 
 // Package charmrepo implements access to charm repositories.
 
-package charmrepo
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
 import (
 	"fmt"

--- a/testing/charm.go
+++ b/testing/charm.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package testing // import "gopkg.in/juju/charmrepo.v2-unstable/testing"
 
 import (
 	"fmt"

--- a/testing/mockstore.go
+++ b/testing/mockstore.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package testing // import "gopkg.in/juju/charmrepo.v2-unstable/testing"
 
 import (
 	"bytes"

--- a/testing/suite.go
+++ b/testing/suite.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package testing // import "gopkg.in/juju/charmrepo.v2-unstable/testing"
 
 import (
 	jujutesting "github.com/juju/testing"

--- a/testing/testcharm.go
+++ b/testing/testcharm.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testing
+package testing // import "gopkg.in/juju/charmrepo.v2-unstable/testing"
 
 import (
 	"archive/zip"


### PR DESCRIPTION
We should have them anyway, and this will enable CI to know
the correct import path when it's using a feature branch.