### PR TITLE
Add an API data type for resources.

### DIFF
--- a/csclient/params/helpers.go
+++ b/csclient/params/helpers.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+import (
+	"gopkg.in/juju/charm.v6-unstable/resource"
+)
+
+// Resource2API converts a charm resource into an API Resource struct.
+func Resource2API(res resource.Resource) Resource {
+	return Resource{
+		Name:        res.Name,
+		Type:        res.Type.String(),
+		Path:        res.Path,
+		Description: res.Description,
+		Origin:      res.Origin.String(),
+		Revision:    res.Revision,
+		Fingerprint: res.Fingerprint.Bytes(),
+		Size:        res.Size,
+	}
+}
+
+// API2Resource converts an API Resource struct into
+// a charm resource.
+func API2Resource(apiInfo Resource) (resource.Resource, error) {
+	var res resource.Resource
+
+	rtype, err := resource.ParseType(apiInfo.Type)
+	if err != nil {
+		return res, err
+	}
+
+	origin, err := resource.ParseOrigin(apiInfo.Origin)
+	if err != nil {
+		return res, err
+	}
+
+	fp, err := deserializeFingerprint(apiInfo.Fingerprint)
+	if err != nil {
+		return res, err
+	}
+
+	res = resource.Resource{
+		Meta: resource.Meta{
+			Name:        apiInfo.Name,
+			Type:        rtype,
+			Path:        apiInfo.Path,
+			Description: apiInfo.Description,
+		},
+		Origin:      origin,
+		Revision:    apiInfo.Revision,
+		Fingerprint: fp,
+		Size:        apiInfo.Size,
+	}
+
+	if err := res.Validate(); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// deserializeFingerprint converts the serialized fingerprint back into
+// a Fingerprint. "zero" values are treated appropriately.
+func deserializeFingerprint(fpSum []byte) (resource.Fingerprint, error) {
+	if len(fpSum) == 0 {
+		return resource.Fingerprint{}, nil
+	}
+	return resource.NewFingerprint(fpSum)
+}

--- a/csclient/params/helpers.go
+++ b/csclient/params/helpers.go
@@ -4,6 +4,7 @@
 package params
 
 import (
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable/resource"
 )
 
@@ -28,17 +29,17 @@ func API2Resource(apiInfo Resource) (resource.Resource, error) {
 
 	rtype, err := resource.ParseType(apiInfo.Type)
 	if err != nil {
-		return res, err
+		return res, errgo.Mask(err, errgo.Any)
 	}
 
 	origin, err := resource.ParseOrigin(apiInfo.Origin)
 	if err != nil {
-		return res, err
+		return res, errgo.Mask(err, errgo.Any)
 	}
 
 	fp, err := deserializeFingerprint(apiInfo.Fingerprint)
 	if err != nil {
-		return res, err
+		return res, errgo.Mask(err, errgo.Any)
 	}
 
 	res = resource.Resource{
@@ -55,7 +56,7 @@ func API2Resource(apiInfo Resource) (resource.Resource, error) {
 	}
 
 	if err := res.Validate(); err != nil {
-		return res, err
+		return res, errgo.Mask(err, errgo.Any)
 	}
 	return res, nil
 }
@@ -66,5 +67,9 @@ func deserializeFingerprint(fpSum []byte) (resource.Fingerprint, error) {
 	if len(fpSum) == 0 {
 		return resource.Fingerprint{}, nil
 	}
-	return resource.NewFingerprint(fpSum)
+	fp, err := resource.NewFingerprint(fpSum)
+	if err != nil {
+		return fp, errgo.Mask(err, errgo.Any)
+	}
+	return fp, nil
 }

--- a/csclient/params/helpers_test.go
+++ b/csclient/params/helpers_test.go
@@ -51,7 +51,7 @@ func (HelpersSuite) TestResource2API(c *gc.C) {
 	})
 }
 
-func (HelpersSuite) TestAPI2ResourceNoError(c *gc.C) {
+func (HelpersSuite) TestAPI2ResourceFull(c *gc.C) {
 	res, err := params.API2Resource(params.Resource{
 		Name:        "spam",
 		Type:        "file",
@@ -77,6 +77,33 @@ func (HelpersSuite) TestAPI2ResourceNoError(c *gc.C) {
 		Revision:    1,
 		Fingerprint: fp,
 		Size:        10,
+	}
+	err = expected.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(res, jc.DeepEquals, expected)
+}
+
+func (HelpersSuite) TestAPI2ResourceBasic(c *gc.C) {
+	res, err := params.API2Resource(params.Resource{
+		Name:   "spam",
+		Type:   "file",
+		Path:   "spam.tgz",
+		Origin: "upload",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := resource.Resource{
+		Meta: resource.Meta{
+			Name:        "spam",
+			Type:        resource.TypeFile,
+			Path:        "spam.tgz",
+			Description: "",
+		},
+		Origin:      resource.OriginUpload,
+		Revision:    0,
+		Fingerprint: resource.Fingerprint{},
+		Size:        0,
 	}
 	err = expected.Validate()
 	c.Assert(err, jc.ErrorIsNil)

--- a/csclient/params/helpers_test.go
+++ b/csclient/params/helpers_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable/resource"
+
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+)
+
+const fingerprint = "123456789012345678901234567890123456789012345678"
+
+type HelpersSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&HelpersSuite{})
+
+func (HelpersSuite) TestResource2API(c *gc.C) {
+	fp, err := resource.NewFingerprint([]byte(fingerprint))
+	c.Assert(err, jc.ErrorIsNil)
+	res := resource.Resource{
+		Meta: resource.Meta{
+			Name:        "spam",
+			Type:        resource.TypeFile,
+			Path:        "spam.tgz",
+			Description: "you need it",
+		},
+		Origin:      resource.OriginUpload,
+		Revision:    1,
+		Fingerprint: fp,
+		Size:        10,
+	}
+	err = res.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+	apiInfo := params.Resource2API(res)
+
+	c.Check(apiInfo, jc.DeepEquals, params.Resource{
+		Name:        "spam",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Description: "you need it",
+		Origin:      "upload",
+		Revision:    1,
+		Fingerprint: []byte(fingerprint),
+		Size:        10,
+	})
+}
+
+func (HelpersSuite) TestAPI2Resource(c *gc.C) {
+	res, err := params.API2Resource(params.Resource{
+		Name:        "spam",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Description: "you need it",
+		Origin:      "upload",
+		Revision:    1,
+		Fingerprint: []byte(fingerprint),
+		Size:        10,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	fp, err := resource.NewFingerprint([]byte(fingerprint))
+	c.Assert(err, jc.ErrorIsNil)
+	expected := resource.Resource{
+		Meta: resource.Meta{
+			Name:        "spam",
+			Type:        resource.TypeFile,
+			Path:        "spam.tgz",
+			Description: "you need it",
+		},
+		Origin:      resource.OriginUpload,
+		Revision:    1,
+		Fingerprint: fp,
+		Size:        10,
+	}
+	err = expected.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(res, jc.DeepEquals, expected)
+}

--- a/csclient/params/helpers_test.go
+++ b/csclient/params/helpers_test.go
@@ -126,6 +126,49 @@ func (HelpersSuite) TestAPI2ResourceBadFingerprint(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `invalid fingerprint \(too big\)`)
 }
 
+func (HelpersSuite) TestAPI2ResourceEmptyFingerprintNoSize(c *gc.C) {
+	res, err := params.API2Resource(params.Resource{
+		Name:        "spam",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Origin:      "upload",
+		Revision:    0,
+		Fingerprint: nil,
+		Size:        0,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := resource.Resource{
+		Meta: resource.Meta{
+			Name: "spam",
+			Type: resource.TypeFile,
+			Path: "spam.tgz",
+		},
+		Origin:      resource.OriginUpload,
+		Revision:    0,
+		Fingerprint: resource.Fingerprint{},
+		Size:        0,
+	}
+	err = expected.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(res, jc.DeepEquals, expected)
+}
+
+func (HelpersSuite) TestAPI2ResourceEmptyFingerprintWithSize(c *gc.C) {
+	_, err := params.API2Resource(params.Resource{
+		Name:        "spam",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Origin:      "upload",
+		Revision:    0,
+		Fingerprint: nil,
+		Size:        10,
+	})
+
+	c.Check(err, gc.ErrorMatches, `missing fingerprint`)
+}
+
 func (HelpersSuite) TestAPI2ResourceValidateFailed(c *gc.C) {
 	_, err := params.API2Resource(params.Resource{
 		Name:        "",

--- a/csclient/params/helpers_test.go
+++ b/csclient/params/helpers_test.go
@@ -31,7 +31,7 @@ func (HelpersSuite) TestResource2API(c *gc.C) {
 			Description: "you need it",
 		},
 		Origin:      resource.OriginUpload,
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: fp,
 		Size:        10,
 	}
@@ -45,7 +45,7 @@ func (HelpersSuite) TestResource2API(c *gc.C) {
 		Path:        "spam.tgz",
 		Description: "you need it",
 		Origin:      "upload",
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: []byte(fingerprint),
 		Size:        10,
 	})
@@ -58,7 +58,7 @@ func (HelpersSuite) TestAPI2ResourceFull(c *gc.C) {
 		Path:        "spam.tgz",
 		Description: "you need it",
 		Origin:      "upload",
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: []byte(fingerprint),
 		Size:        10,
 	})
@@ -74,7 +74,7 @@ func (HelpersSuite) TestAPI2ResourceFull(c *gc.C) {
 			Description: "you need it",
 		},
 		Origin:      resource.OriginUpload,
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: fp,
 		Size:        10,
 	}
@@ -117,7 +117,7 @@ func (HelpersSuite) TestAPI2ResourceBadType(c *gc.C) {
 		Type:        "<bogus>",
 		Path:        "spam.tgz",
 		Origin:      "upload",
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: []byte(fingerprint),
 		Size:        10,
 	})
@@ -131,7 +131,7 @@ func (HelpersSuite) TestAPI2ResourceBadOrigin(c *gc.C) {
 		Type:        "file",
 		Path:        "spam.tgz",
 		Origin:      "<bogus>",
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: []byte(fingerprint),
 		Size:        10,
 	})
@@ -145,7 +145,7 @@ func (HelpersSuite) TestAPI2ResourceBadFingerprint(c *gc.C) {
 		Type:        "file",
 		Path:        "spam.tgz",
 		Origin:      "upload",
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: []byte(fingerprint + "1"),
 		Size:        10,
 	})
@@ -202,7 +202,7 @@ func (HelpersSuite) TestAPI2ResourceValidateFailed(c *gc.C) {
 		Type:        "file",
 		Path:        "spam.tgz",
 		Origin:      "upload",
-		Revision:    1,
+		Revision:    0,
 		Fingerprint: []byte(fingerprint),
 		Size:        10,
 	})

--- a/csclient/params/helpers_test.go
+++ b/csclient/params/helpers_test.go
@@ -51,7 +51,7 @@ func (HelpersSuite) TestResource2API(c *gc.C) {
 	})
 }
 
-func (HelpersSuite) TestAPI2Resource(c *gc.C) {
+func (HelpersSuite) TestAPI2ResourceNoError(c *gc.C) {
 	res, err := params.API2Resource(params.Resource{
 		Name:        "spam",
 		Type:        "file",
@@ -82,4 +82,60 @@ func (HelpersSuite) TestAPI2Resource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, expected)
+}
+
+func (HelpersSuite) TestAPI2ResourceBadType(c *gc.C) {
+	_, err := params.API2Resource(params.Resource{
+		Name:        "spam",
+		Type:        "<bogus>",
+		Path:        "spam.tgz",
+		Origin:      "upload",
+		Revision:    1,
+		Fingerprint: []byte(fingerprint),
+		Size:        10,
+	})
+
+	c.Check(err, gc.ErrorMatches, `unsupported resource type "<bogus>"`)
+}
+
+func (HelpersSuite) TestAPI2ResourceBadOrigin(c *gc.C) {
+	_, err := params.API2Resource(params.Resource{
+		Name:        "spam",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Origin:      "<bogus>",
+		Revision:    1,
+		Fingerprint: []byte(fingerprint),
+		Size:        10,
+	})
+
+	c.Check(err, gc.ErrorMatches, `unknown origin "<bogus>"`)
+}
+
+func (HelpersSuite) TestAPI2ResourceBadFingerprint(c *gc.C) {
+	_, err := params.API2Resource(params.Resource{
+		Name:        "spam",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Origin:      "upload",
+		Revision:    1,
+		Fingerprint: []byte(fingerprint + "1"),
+		Size:        10,
+	})
+
+	c.Check(err, gc.ErrorMatches, `invalid fingerprint \(too big\)`)
+}
+
+func (HelpersSuite) TestAPI2ResourceValidateFailed(c *gc.C) {
+	_, err := params.API2Resource(params.Resource{
+		Name:        "",
+		Type:        "file",
+		Path:        "spam.tgz",
+		Origin:      "upload",
+		Revision:    1,
+		Fingerprint: []byte(fingerprint),
+		Size:        10,
+	})
+
+	c.Check(err, gc.ErrorMatches, `.*resource missing name`)
 }

--- a/csclient/params/helpers_test.go
+++ b/csclient/params/helpers_test.go
@@ -111,6 +111,18 @@ func (HelpersSuite) TestAPI2ResourceBasic(c *gc.C) {
 	c.Check(res, jc.DeepEquals, expected)
 }
 
+func (HelpersSuite) TestAPI2ResourceNegativeRevision(c *gc.C) {
+	_, err := params.API2Resource(params.Resource{
+		Name:     "spam",
+		Type:     "file",
+		Path:     "spam.tgz",
+		Origin:   "upload",
+		Revision: -1,
+	})
+
+	c.Check(err, gc.ErrorMatches, `invalid resource \(revision must be non-negative\)`)
+}
+
 func (HelpersSuite) TestAPI2ResourceBadType(c *gc.C) {
 	_, err := params.API2Resource(params.Resource{
 		Name:        "spam",

--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -260,6 +260,33 @@ type WhoAmIResponse struct {
 	Groups []string
 }
 
+// Resource describes a resource in the charm store.
+type Resource struct {
+	// Name identifies the resource.
+	Name string `json:"name"`
+
+	// Type is the name of the resource type.
+	Type string `json:"type"`
+
+	// Path is where the resource will be stored.
+	Path string `json:"path"`
+
+	// Description contains user-facing info about the resource.
+	Description string `json:"description,omitempty"`
+
+	// Origin is where the resource will come from.
+	Origin string `json:"origin"`
+
+	// Revision is the revision, if applicable.
+	Revision int `json:"revision"`
+
+	// Fingerprint is the SHA-384 checksum for the resource blob.
+	Fingerprint []byte `json:"fingerprint"`
+
+	// Size is the size of the resource, in bytes.
+	Size int64
+}
+
 const (
 	// BzrDigestKey is the extra-info key used to store the Bazaar digest
 	BzrDigestKey = "bzr-digest"

--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -263,25 +263,25 @@ type WhoAmIResponse struct {
 // Resource describes a resource in the charm store.
 type Resource struct {
 	// Name identifies the resource.
-	Name string `json:"name"`
+	Name string
 
 	// Type is the name of the resource type.
-	Type string `json:"type"`
+	Type string
 
 	// Path is where the resource will be stored.
-	Path string `json:"path"`
+	Path string
 
 	// Description contains user-facing info about the resource.
-	Description string `json:"description,omitempty"`
+	Description string `json:",omitempty"`
 
 	// Origin is where the resource will come from.
-	Origin string `json:"origin"`
+	Origin string
 
 	// Revision is the revision, if applicable.
-	Revision int `json:"revision"`
+	Revision int
 
 	// Fingerprint is the SHA-384 checksum for the resource blob.
-	Fingerprint []byte `json:"fingerprint"`
+	Fingerprint []byte
 
 	// Size is the size of the resource, in bytes.
 	Size int64


### PR DESCRIPTION
This provides a stable over-the-wire format that maps onto the charm/resource.Resource type.