### PR TITLE
Prepare to drop some CharmStore methods.

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -279,6 +279,10 @@ const JujuMetadataHTTPHeader = csclient.JujuMetadataHTTPHeader
 // attributes set.
 func (s *CharmStore) WithJujuAttrs(attrs map[string]string) *CharmStore {
 	newRepo := *s
-	newRepo.client = newRepo.client.WithJujuAttrs(attrs)
+	header := make(http.Header)
+	for k, v := range attrs {
+		header.Add(JujuMetadataHTTPHeader, k+"="+v)
+	}
+	newRepo.client.SetHTTPHeader(header)
 	return &newRepo
 }

--- a/charmstore.go
+++ b/charmstore.go
@@ -273,16 +273,12 @@ func (s *CharmStore) WithTestMode() *CharmStore {
 
 // JujuMetadataHTTPHeader is the HTTP header name used to send Juju metadata
 // attributes to the charm store.
-const JujuMetadataHTTPHeader = "Juju-Metadata"
+const JujuMetadataHTTPHeader = csclient.JujuMetadataHTTPHeader
 
 // WithJujuAttrs returns a repository Interface with the Juju metadata
 // attributes set.
 func (s *CharmStore) WithJujuAttrs(attrs map[string]string) *CharmStore {
 	newRepo := *s
-	header := make(http.Header)
-	for k, v := range attrs {
-		header.Add(JujuMetadataHTTPHeader, k+"="+v)
-	}
-	newRepo.client.SetHTTPHeader(header)
+	newRepo.client = newRepo.client.WithJujuAttrs(attrs)
 	return &newRepo
 }

--- a/charmstore_going_away.go
+++ b/charmstore_going_away.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
+
+// This file may go away once Juju stops using anything here.
+
+import (
+	"net/http"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+)
+
+// URL returns the root endpoint URL of the charm store.
+func (s *CharmStore) URL() string {
+	return s.client.ServerURL()
+}
+
+// Latest returns the most current revision for each of the identified
+// charms. The revision in the provided charm URLs is ignored.
+func (s *CharmStore) Latest(curls ...*charm.URL) ([]CharmRevision, error) {
+	results, err := s.client.Latest(curls)
+	if err != nil {
+		return nil, err
+	}
+
+	var responses []CharmRevision
+	for i, result := range results {
+		response := CharmRevision{
+			Revision: result.Revision,
+			Sha256:   result.Sha256,
+			Err:      result.Err,
+		}
+		if errgo.Cause(result.Err) == params.ErrNotFound {
+			curl := curls[i].WithRevision(-1)
+			response.Err = CharmNotFound(curl.String())
+		}
+		responses = append(responses, response)
+	}
+	return responses, nil
+}
+
+// WithTestMode returns a repository Interface where test mode is enabled,
+// meaning charm store download stats are not increased when charms are
+// retrieved.
+func (s *CharmStore) WithTestMode() *CharmStore {
+	newRepo := *s
+	newRepo.client.DisableStats()
+	return &newRepo
+}
+
+// JujuMetadataHTTPHeader is the HTTP header name used to send Juju metadata
+// attributes to the charm store.
+const JujuMetadataHTTPHeader = csclient.JujuMetadataHTTPHeader
+
+// WithJujuAttrs returns a repository Interface with the Juju metadata
+// attributes set.
+func (s *CharmStore) WithJujuAttrs(attrs map[string]string) *CharmStore {
+	newRepo := *s
+	header := make(http.Header)
+	for k, v := range attrs {
+		header.Add(JujuMetadataHTTPHeader, k+"="+v)
+	}
+	newRepo.client.SetHTTPHeader(header)
+	return &newRepo
+}

--- a/charmstore_going_away_test.go
+++ b/charmstore_going_away_test.go
@@ -1,0 +1,166 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmrepo_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"gopkg.in/juju/charmrepo.v2-unstable"
+)
+
+func (s *charmStoreSuite) TestURL(c *gc.C) {
+	repo := charmrepo.NewCharmStore(charmrepo.NewCharmStoreParams{
+		URL: "https://1.2.3.4/charmstore",
+	})
+	c.Assert(repo.URL(), gc.Equals, "https://1.2.3.4/charmstore")
+}
+
+func (s *charmStoreRepoSuite) TestLatest(c *gc.C) {
+	// Add some charms to the charm store.
+	s.addCharm(c, "~who/trusty/mysql-0", "mysql")
+	s.addCharm(c, "~who/precise/wordpress-1", "wordpress")
+	s.addCharm(c, "~dalek/trusty/riak-0", "riak")
+	s.addCharm(c, "~dalek/trusty/riak-1", "riak")
+	s.addCharm(c, "~dalek/trusty/riak-3", "riak")
+	_, url := s.addCharm(c, "~who/utopic/varnish-0", "varnish")
+
+	// Change permissions on one of the charms so that it is not readable by
+	// anyone.
+	err := s.client.Put("/"+url.Path()+"/meta/perm/read", []string{"dalek"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Calculate and store the expected hashes for the uploaded charms.
+	mysqlHash := hashOfCharm(c, "mysql")
+	wordpressHash := hashOfCharm(c, "wordpress")
+	riakHash := hashOfCharm(c, "riak")
+
+	// Define the tests to be run.
+	tests := []struct {
+		about string
+		urls  []*charm.URL
+		revs  []charmrepo.CharmRevision
+	}{{
+		about: "no urls",
+	}, {
+		about: "charm not found",
+		urls:  []*charm.URL{charm.MustParseURL("cs:trusty/no-such-42")},
+		revs: []charmrepo.CharmRevision{{
+			Err: charmrepo.CharmNotFound("cs:trusty/no-such"),
+		}},
+	}, {
+		about: "resolve",
+		urls: []*charm.URL{
+			charm.MustParseURL("cs:~who/trusty/mysql-42"),
+			charm.MustParseURL("cs:~who/trusty/mysql-0"),
+			charm.MustParseURL("cs:~who/trusty/mysql"),
+		},
+		revs: []charmrepo.CharmRevision{{
+			Revision: 0,
+			Sha256:   mysqlHash,
+		}, {
+			Revision: 0,
+			Sha256:   mysqlHash,
+		}, {
+			Revision: 0,
+			Sha256:   mysqlHash,
+		}},
+	}, {
+		about: "multiple charms",
+		urls: []*charm.URL{
+			charm.MustParseURL("cs:~who/precise/wordpress"),
+			charm.MustParseURL("cs:~who/trusty/mysql-47"),
+			charm.MustParseURL("cs:~dalek/trusty/no-such"),
+			charm.MustParseURL("cs:~dalek/trusty/riak-0"),
+		},
+		revs: []charmrepo.CharmRevision{{
+			Revision: 1,
+			Sha256:   wordpressHash,
+		}, {
+			Revision: 0,
+			Sha256:   mysqlHash,
+		}, {
+			Err: charmrepo.CharmNotFound("cs:~dalek/trusty/no-such"),
+		}, {
+			Revision: 3,
+			Sha256:   riakHash,
+		}},
+	}, {
+		about: "unauthorized",
+		urls: []*charm.URL{
+			charm.MustParseURL("cs:~who/precise/wordpress"),
+			url,
+		},
+		revs: []charmrepo.CharmRevision{{
+			Revision: 1,
+			Sha256:   wordpressHash,
+		}, {
+			Err: charmrepo.CharmNotFound("cs:~who/utopic/varnish"),
+		}},
+	}}
+
+	// Run the tests.
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.about)
+		revs, err := s.repo.Latest(test.urls...)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(revs, jc.DeepEquals, test.revs)
+	}
+}
+
+func (s *charmStoreRepoSuite) TestGetWithTestMode(c *gc.C) {
+	_, url := s.addCharm(c, "~who/precise/wordpress-42", "wordpress")
+
+	// Use a repo with test mode enabled to download a charm a couple of
+	// times, and check the downloads count is not increased.
+	repo := s.repo.WithTestMode()
+	_, err := repo.Get(url)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = repo.Get(url)
+	c.Assert(err, jc.ErrorIsNil)
+	s.checkCharmDownloads(c, url, 0)
+}
+
+func (s *charmStoreRepoSuite) TestGetWithJujuAttrs(c *gc.C) {
+	_, url := s.addCharm(c, "trusty/riak-0", "riak")
+
+	// Set up a proxy server that stores the request header.
+	var header http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header = r.Header
+		s.handler.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	repo := charmrepo.NewCharmStore(charmrepo.NewCharmStoreParams{
+		URL: srv.URL,
+	})
+
+	// Make a first request without Juju attrs.
+	_, err := repo.Get(url)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(header.Get(charmrepo.JujuMetadataHTTPHeader), gc.Equals, "")
+
+	// Make a second request after setting Juju attrs.
+	repo = repo.WithJujuAttrs(map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
+	_, err = repo.Get(url)
+	c.Assert(err, jc.ErrorIsNil)
+	values := header[http.CanonicalHeaderKey(charmrepo.JujuMetadataHTTPHeader)]
+	sort.Strings(values)
+	c.Assert(values, jc.DeepEquals, []string{"k1=v1", "k2=v2"})
+
+	// Make a third request after restoring empty attrs.
+	repo = repo.WithJujuAttrs(nil)
+	_, err = repo.Get(url)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(header.Get(charmrepo.JujuMetadataHTTPHeader), gc.Equals, "")
+}

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -36,16 +35,9 @@ type charmStoreSuite struct {
 
 var _ = gc.Suite(&charmStoreSuite{})
 
-func (s *charmStoreSuite) TestURL(c *gc.C) {
-	repo := charmrepo.NewCharmStore(charmrepo.NewCharmStoreParams{
-		URL: "https://1.2.3.4/charmstore",
-	})
-	c.Assert(repo.URL(), gc.Equals, "https://1.2.3.4/charmstore")
-}
-
 func (s *charmStoreSuite) TestDefaultURL(c *gc.C) {
 	repo := charmrepo.NewCharmStore(charmrepo.NewCharmStoreParams{})
-	c.Assert(repo.URL(), gc.Equals, csclient.ServerURL)
+	c.Assert(repo.Client().ServerURL(), gc.Equals, csclient.ServerURL)
 }
 
 type charmStoreBaseSuite struct {
@@ -199,7 +191,7 @@ func (s *charmStoreRepoSuite) TestNewCharmStoreFromClient(c *gc.C) {
 
 	repo := charmrepo.NewCharmStoreFromClient(client)
 
-	c.Check(repo.URL(), gc.Equals, csclient.ServerURL)
+	c.Check(repo.Client().ServerURL(), gc.Equals, csclient.ServerURL)
 }
 
 func (s *charmStoreRepoSuite) TestGet(c *gc.C) {
@@ -305,57 +297,6 @@ func (s *charmStoreRepoSuite) TestGetIncreaseStats(c *gc.C) {
 	s.checkCharmDownloads(c, url, 2)
 }
 
-func (s *charmStoreRepoSuite) TestGetWithTestMode(c *gc.C) {
-	_, url := s.addCharm(c, "~who/precise/wordpress-42", "wordpress")
-
-	// Use a repo with test mode enabled to download a charm a couple of
-	// times, and check the downloads count is not increased.
-	repo := s.repo.WithTestMode()
-	_, err := repo.Get(url)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = repo.Get(url)
-	c.Assert(err, jc.ErrorIsNil)
-	s.checkCharmDownloads(c, url, 0)
-}
-
-func (s *charmStoreRepoSuite) TestGetWithJujuAttrs(c *gc.C) {
-	_, url := s.addCharm(c, "trusty/riak-0", "riak")
-
-	// Set up a proxy server that stores the request header.
-	var header http.Header
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		header = r.Header
-		s.handler.ServeHTTP(w, r)
-	}))
-	defer srv.Close()
-
-	repo := charmrepo.NewCharmStore(charmrepo.NewCharmStoreParams{
-		URL: srv.URL,
-	})
-
-	// Make a first request without Juju attrs.
-	_, err := repo.Get(url)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(header.Get(charmrepo.JujuMetadataHTTPHeader), gc.Equals, "")
-
-	// Make a second request after setting Juju attrs.
-	repo = repo.WithJujuAttrs(map[string]string{
-		"k1": "v1",
-		"k2": "v2",
-	})
-	_, err = repo.Get(url)
-	c.Assert(err, jc.ErrorIsNil)
-	values := header[http.CanonicalHeaderKey(charmrepo.JujuMetadataHTTPHeader)]
-	sort.Strings(values)
-	c.Assert(values, jc.DeepEquals, []string{"k1=v1", "k2=v2"})
-
-	// Make a third request after restoring empty attrs.
-	repo = repo.WithJujuAttrs(nil)
-	_, err = repo.Get(url)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(header.Get(charmrepo.JujuMetadataHTTPHeader), gc.Equals, "")
-}
-
 func (s *charmStoreRepoSuite) TestGetErrorBundle(c *gc.C) {
 	ch, err := s.repo.Get(charm.MustParseURL("cs:bundle/django"))
 	c.Assert(err, gc.ErrorMatches, `expected a charm URL, got bundle URL "cs:bundle/django"`)
@@ -436,98 +377,6 @@ func (s *charmStoreRepoSuite) TestGetBundleErrorCharm(c *gc.C) {
 	ch, err := s.repo.GetBundle(charm.MustParseURL("cs:trusty/django"))
 	c.Assert(err, gc.ErrorMatches, `expected a bundle URL, got charm URL "cs:trusty/django"`)
 	c.Assert(ch, gc.IsNil)
-}
-
-func (s *charmStoreRepoSuite) TestLatest(c *gc.C) {
-	// Add some charms to the charm store.
-	s.addCharm(c, "~who/trusty/mysql-0", "mysql")
-	s.addCharm(c, "~who/precise/wordpress-1", "wordpress")
-	s.addCharm(c, "~dalek/trusty/riak-0", "riak")
-	s.addCharm(c, "~dalek/trusty/riak-1", "riak")
-	s.addCharm(c, "~dalek/trusty/riak-3", "riak")
-	_, url := s.addCharm(c, "~who/utopic/varnish-0", "varnish")
-
-	// Change permissions on one of the charms so that it is not readable by
-	// anyone.
-	err := s.client.Put("/"+url.Path()+"/meta/perm/read", []string{"dalek"})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Calculate and store the expected hashes for the uploaded charms.
-	mysqlHash := hashOfCharm(c, "mysql")
-	wordpressHash := hashOfCharm(c, "wordpress")
-	riakHash := hashOfCharm(c, "riak")
-
-	// Define the tests to be run.
-	tests := []struct {
-		about string
-		urls  []*charm.URL
-		revs  []charmrepo.CharmRevision
-	}{{
-		about: "no urls",
-	}, {
-		about: "charm not found",
-		urls:  []*charm.URL{charm.MustParseURL("cs:trusty/no-such-42")},
-		revs: []charmrepo.CharmRevision{{
-			Err: charmrepo.CharmNotFound("cs:trusty/no-such"),
-		}},
-	}, {
-		about: "resolve",
-		urls: []*charm.URL{
-			charm.MustParseURL("cs:~who/trusty/mysql-42"),
-			charm.MustParseURL("cs:~who/trusty/mysql-0"),
-			charm.MustParseURL("cs:~who/trusty/mysql"),
-		},
-		revs: []charmrepo.CharmRevision{{
-			Revision: 0,
-			Sha256:   mysqlHash,
-		}, {
-			Revision: 0,
-			Sha256:   mysqlHash,
-		}, {
-			Revision: 0,
-			Sha256:   mysqlHash,
-		}},
-	}, {
-		about: "multiple charms",
-		urls: []*charm.URL{
-			charm.MustParseURL("cs:~who/precise/wordpress"),
-			charm.MustParseURL("cs:~who/trusty/mysql-47"),
-			charm.MustParseURL("cs:~dalek/trusty/no-such"),
-			charm.MustParseURL("cs:~dalek/trusty/riak-0"),
-		},
-		revs: []charmrepo.CharmRevision{{
-			Revision: 1,
-			Sha256:   wordpressHash,
-		}, {
-			Revision: 0,
-			Sha256:   mysqlHash,
-		}, {
-			Err: charmrepo.CharmNotFound("cs:~dalek/trusty/no-such"),
-		}, {
-			Revision: 3,
-			Sha256:   riakHash,
-		}},
-	}, {
-		about: "unauthorized",
-		urls: []*charm.URL{
-			charm.MustParseURL("cs:~who/precise/wordpress"),
-			url,
-		},
-		revs: []charmrepo.CharmRevision{{
-			Revision: 1,
-			Sha256:   wordpressHash,
-		}, {
-			Err: charmrepo.CharmNotFound("cs:~who/utopic/varnish"),
-		}},
-	}}
-
-	// Run the tests.
-	for i, test := range tests {
-		c.Logf("test %d: %s", i, test.about)
-		revs, err := s.repo.Latest(test.urls...)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(revs, jc.DeepEquals, test.revs)
-	}
 }
 
 func (s *charmStoreRepoSuite) TestResolve(c *gc.C) {

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -866,15 +866,3 @@ func (cs *Client) Latest(curls []*charm.URL) ([]params.CharmRevision, error) {
 // JujuMetadataHTTPHeader is the HTTP header name used to send Juju metadata
 // attributes to the charm store.
 const JujuMetadataHTTPHeader = "Juju-Metadata"
-
-// WithJujuAttrs returns a repository Interface with the Juju metadata
-// attributes set.
-func (cs *Client) WithJujuAttrs(attrs map[string]string) *Client {
-	newClient := *cs
-	header := make(http.Header)
-	for k, v := range attrs {
-		header.Add(JujuMetadataHTTPHeader, k+"="+v)
-	}
-	newClient.SetHTTPHeader(header)
-	return &newClient
-}

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -808,3 +808,57 @@ func (cs *Client) WhoAmI() (*params.WhoAmIResponse, error) {
 	}
 	return &response, nil
 }
+
+// Latest returns the most current revision for each of the identified
+// charms. The revision in the provided charm URLs is ignored.
+func (cs *Client) Latest(curls []*charm.URL) ([]params.CharmRevision, error) {
+	if len(curls) == 0 {
+		return nil, nil
+	}
+
+	// Prepare the request to the charm store.
+	urls := make([]string, len(curls))
+	values := url.Values{}
+	// Include the ignore-auth flag so that non-public results do not generate
+	// an error for the whole request.
+	values.Add("ignore-auth", "1")
+	values.Add("include", "id-revision")
+	values.Add("include", "hash256")
+	for i, curl := range curls {
+		url := curl.WithRevision(-1).String()
+		urls[i] = url
+		values.Add("id", url)
+	}
+	u := url.URL{
+		Path:     "/meta/any",
+		RawQuery: values.Encode(),
+	}
+
+	// Execute the request and retrieve results.
+	var results map[string]struct {
+		Meta struct {
+			IdRevision params.IdRevisionResponse `json:"id-revision"`
+			Hash256    params.HashResponse       `json:"hash256"`
+		}
+	}
+	if err := cs.Get(u.String(), &results); err != nil {
+		return nil, errgo.NoteMask(err, "cannot get metadata from the charm store", errgo.Any)
+	}
+
+	// Build the response.
+	responses := make([]params.CharmRevision, len(curls))
+	for i, url := range urls {
+		result, found := results[url]
+		if !found {
+			responses[i] = params.CharmRevision{
+				Err: params.ErrNotFound,
+			}
+			continue
+		}
+		responses[i] = params.CharmRevision{
+			Revision: result.Meta.IdRevision.Revision,
+			Sha256:   result.Meta.Hash256.Sum,
+		}
+	}
+	return responses, nil
+}

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -862,3 +862,19 @@ func (cs *Client) Latest(curls []*charm.URL) ([]params.CharmRevision, error) {
 	}
 	return responses, nil
 }
+
+// JujuMetadataHTTPHeader is the HTTP header name used to send Juju metadata
+// attributes to the charm store.
+const JujuMetadataHTTPHeader = "Juju-Metadata"
+
+// WithJujuAttrs returns a repository Interface with the Juju metadata
+// attributes set.
+func (cs *Client) WithJujuAttrs(attrs map[string]string) *Client {
+	newClient := *cs
+	header := make(http.Header)
+	for k, v := range attrs {
+		header.Add(JujuMetadataHTTPHeader, k+"="+v)
+	}
+	newClient.SetHTTPHeader(header)
+	return &newClient
+}

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -16,6 +16,7 @@ import (
 	neturl "net/url"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -1604,6 +1605,40 @@ func (s *suite) TestLatest(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(revs, jc.DeepEquals, test.revs)
 	}
+}
+
+func (s *suite) TestGetWithJujuAttrs(c *gc.C) {
+	_, url := s.addCharm(c, "trusty/riak-0", "riak")
+
+	// Set up a proxy server that stores the request header.
+	var header http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header = r.Header
+		s.handler.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	// Make a first request without Juju attrs.
+	_, _, _, _, err := s.client.GetArchive(url)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(header.Get(csclient.JujuMetadataHTTPHeader), gc.Equals, "")
+
+	// Make a second request after setting Juju attrs.
+	client := s.client.WithJujuAttrs(map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
+	_, _, _, _, err = s.client.GetArchive(url)
+	c.Assert(err, jc.ErrorIsNil)
+	values := header[http.CanonicalHeaderKey(csclient.JujuMetadataHTTPHeader)]
+	sort.Strings(values)
+	c.Assert(values, jc.DeepEquals, []string{"k1=v1", "k2=v2"})
+
+	// Make a third request after restoring empty attrs.
+	client = client.WithJujuAttrs(nil)
+	_, _, _, _, err = s.client.GetArchive(url)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(header.Get(csclient.JujuMetadataHTTPHeader), gc.Equals, "")
 }
 
 // addCharm uploads a charm a promulgated revision to the testing charm store

--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -334,6 +334,14 @@ type ResourceUploadResponse struct {
 	Revision int
 }
 
+// CharmRevision holds the revision number of a charm and any error
+// encountered in retrieving it.
+type CharmRevision struct {
+	Revision int
+	Sha256   string
+	Err      error
+}
+
 const (
 	// BzrDigestKey is the extra-info key used to store the Bazaar digest
 	BzrDigestKey = "bzr-digest"

--- a/legacy.go
+++ b/legacy.go
@@ -185,6 +185,14 @@ func (s *LegacyCharmStore) Event(curl *charm.URL, digest string) (*EventResponse
 	return event, nil
 }
 
+// CharmRevision holds the revision number of a charm and any error
+// encountered in retrieving it.
+type CharmRevision struct {
+	Revision int
+	Sha256   string
+	Err      error
+}
+
 // revisions returns the revisions of the charms referenced by curls.
 func (s *LegacyCharmStore) revisions(curls ...charm.Location) (revisions []CharmRevision, err error) {
 	infos, err := s.Info(curls...)

--- a/params.go
+++ b/params.go
@@ -30,14 +30,6 @@ type EventResponse struct {
 	Time     string   `json:"time,omitempty"`
 }
 
-// CharmRevision holds the revision number of a charm and any error
-// encountered in retrieving it.
-type CharmRevision struct {
-	Revision int
-	Sha256   string
-	Err      error
-}
-
 // ResourceResult holds the resources for a given charm and any error
 // encountered in retrieving them.
 type ResourceResult struct {


### PR DESCRIPTION
The CharmStore type has several exported methods that are not part of Interface.  If the goal is to have CharmStore be a strictly conforming implementation then these methods do not belong.  With the addition of CharmStore.Client() we can remove all but one of the methods.  They are either unnecessary or may be implemented as needed in juju core.  The one remaining method is Latest().  This patch moves it to csclient.Client.

Once core has been updated appropriately, the entire charmstore_going_away.go file may be removed.