### PR TITLE
change GetResource to return the full resource metadata w/ bytes

### DIFF
--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -914,7 +914,7 @@ var getWithBadResponseTests = []struct {
 		Body:          ioutil.NopCloser(&errorReader{"body read error"}),
 		ContentLength: -1,
 	},
-	expectError: "cannot read response body: body read error",
+	expectError: `cannot unmarshal response "": body read error`,
 }, {
 	about: "badly formatted json response",
 	response: &http.Response{


### PR DESCRIPTION
We changed to use a multipart body to return the data, so we don't have to use a bunch of ugly headers.

Also did a little cleanup of some spots where we were unnecessarily reading the full body into memory.