### PR TITLE
csclient: test resources endpoints for real

### DIFF
--- a/csclient/csclient_resources_test.go
+++ b/csclient/csclient_resources_test.go
@@ -27,51 +27,6 @@ type ResourceSuite struct{}
 
 var _ = gc.Suite(ResourceSuite{})
 
-func (ResourceSuite) TestListResources(c *gc.C) {
-	data := "somedata"
-	fp, err := resource.GenerateFingerprint(strings.NewReader(data))
-	c.Assert(err, jc.ErrorIsNil)
-
-	results := map[string][]params.Resource{
-		"cs:quantal/starsay": []params.Resource{
-			{
-				Name:        "data",
-				Type:        "file",
-				Path:        "data.zip",
-				Description: "some zip file",
-				Revision:    1,
-				Fingerprint: fp.Bytes(),
-				Size:        int64(len(data)),
-			},
-		},
-	}
-
-	b, err := json.Marshal(results)
-	c.Assert(err, jc.ErrorIsNil)
-
-	f := &fakeClient{
-		Stub: &testing.Stub{},
-		ReturnDoWithBody: &http.Response{
-			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(b)),
-		},
-	}
-
-	client := Client{bclient: f}
-	url := charm.MustParseURL("cs:quantal/starsay")
-	ret, err := client.ListResources([]*charm.URL{url})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Add the origin to the results - the csclient code is responsible
-	// for adding it.
-	for _, rs := range results {
-		for i := range rs {
-			rs[i].Origin = "store"
-		}
-	}
-	c.Assert(ret, jc.DeepEquals, results)
-}
-
 func (ResourceSuite) TestUploadResource(c *gc.C) {
 	data := []byte("boo!")
 	reader := bytes.NewReader(data)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,11 +9,11 @@ github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03
 github.com/juju/idmclient	git	812a86ff450af958df6665839d93590f27961b08	2016-03-16T15:15:55Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
-github.com/juju/names	git	ef19de31613af3735aa69ba3b40accce2faf7316	2016-03-01T22:07:10Z
+github.com/juju/names	git	8a0aa0963bbacdc790914892e9ff942e94d6f795	2016-03-30T15:05:33Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2016-04-04T09:43:17Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	d1440e84c06d41df4fb3369a2f0c301dbea9ed53	2016-03-28T15:54:33Z
+github.com/juju/utils	git	eb6cb958762135bb61aed1e0951f657c674d427f	2016-04-11T02:40:59Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -24,7 +24,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
-gopkg.in/juju/charmstore.v5-unstable	git	dab0340f56958cb5f5ca007e9d15d4f3b1b1b3cb	2016-03-23T15:22:24Z
+gopkg.in/juju/charmstore.v5-unstable	git	745fa1ca2260cdc9dd5a6df6282da51776baa59f	2016-04-12T11:34:55Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
 gopkg.in/macaroon-bakery.v1	git	fddb3dcd74806133259879d033fdfe92f9e67a8a	2016-04-01T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
We replace some of the mocked tests with tests against the
actual server code.

We also change the ListResources call so that it can work correctly
with the Juju code, simplifying it in the process as discussed online.
