### PR TITLE
Remove size from ResourceData

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -276,12 +276,11 @@ func (s *Client) Publish(id *charm.URL, channels []params.Channel, resources map
 type ResourceData struct {
 	io.ReadCloser
 	Hash string
-	Size int64
 }
 
 // GetResource retrieves byes of the resource with the given name and revision
 // for the given charm, returning a reader its data can be read from,  the
-// SHA384 hash of the data and its size.
+// SHA384 hash of the data.
 //
 // Note that the result must be closed after use.
 func (c *Client) GetResource(id *charm.URL, name string, revision int) (result ResourceData, err error) {
@@ -314,14 +313,9 @@ func (c *Client) GetResource(id *charm.URL, name string, revision int) (result R
 		return result, errgo.Newf("no %s header found in response", params.ContentHashHeader)
 	}
 
-	// Validate the response contents.
-	if resp.ContentLength < 0 {
-		return result, errgo.Newf("no content length found in response")
-	}
 	return ResourceData{
 		ReadCloser: resp.Body,
 		Hash:       hash,
-		Size:       resp.ContentLength,
 	}, nil
 }
 

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -1652,7 +1652,6 @@ func (s *suite) TestUploadResource(c *gc.C) {
 
 		expectHash := fmt.Sprintf("%x", sha512.Sum384([]byte(data)))
 		c.Assert(getResult.Hash, gc.Equals, expectHash)
-		c.Assert(getResult.Size, gc.Equals, int64(len(data)))
 
 		gotData, err := ioutil.ReadAll(getResult)
 		c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
We're not guaranteed to get a content-length from our get request, so we can't
guarantee we'll have anything to put in size.

This is half of a fix for https://bugs.launchpad.net/juju/+bug/1628786