### PR TITLE
Add NewTempCharmStore

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -140,9 +140,16 @@ func (s *CharmStore) GetBundle(curl *charm.URL) (charm.Bundle, error) {
 	return charm.ReadBundleArchive(path)
 }
 
-// Cleanup removes the cache directory and any charms in it.
+// Cleanup removes the cache directory and any charms in it. This is
+// primarily for temp stores, but it will work for stores that use the
+// global cache dir. Don't call it unless you want to delete that
+// cache.
 func (s *CharmStore) Cleanup() error {
-	return os.RemoveAll(s.cacheDir)
+	dir, err := s.getCacheDir()
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	return os.RemoveAll(dir)
 }
 
 // cacheDir returns the directory that this store should save charms

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -599,8 +599,12 @@ func (s *charmStoreRepoSuite) TestSortChannels(c *gc.C) {
 }
 
 func (s *charmStoreRepoSuite) TestTempCharmStore(c *gc.C) {
-	_, url := s.addCharm(c, "~who/trusty/mysql-42", "mysql")
-	client := csclient.New(csclient.Params{URL: csclient.ServerURL})
+	expect, url := s.addCharm(c, "trusty/mysql-0", "mysql")
+	client := csclient.New(csclient.Params{
+		URL:      s.srv.URL,
+		User:     "test-user",
+		Password: "test-password",
+	})
 
 	repo, err := charmrepo.NewTempCharmStore(client)
 	c.Assert(err, jc.ErrorIsNil)
@@ -610,8 +614,9 @@ func (s *charmStoreRepoSuite) TestTempCharmStore(c *gc.C) {
 	globalCache := charmrepo.GetCacheDir(c, s.repo)
 	c.Assert(tempCache, gc.Not(gc.Equals), globalCache)
 
-	_, err = repo.Get(url)
+	ch, err := repo.Get(url)
 	c.Assert(err, jc.ErrorIsNil)
+	checkCharm(c, ch, expect)
 
 	assertFileCount(c, tempCache, 1)
 	assertFileCount(c, globalCache, 0)

--- a/export_test.go
+++ b/export_test.go
@@ -3,4 +3,15 @@
 
 package charmrepo // import "gopkg.in/juju/charmrepo.v2-unstable"
 
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
 var SortChannels = sortChannels
+
+func GetCacheDir(c *gc.C, cs *CharmStore) string {
+	result, err := cs.getCacheDir()
+	c.Assert(err, jc.ErrorIsNil)
+	return result
+}


### PR DESCRIPTION
This uses a private charm cache dir, so we can clean it up without
worrying about other processes trying to read the files in the cache.

Juju controllers will use this when downloading charms so that they aren't
kept around - they're already cached in the blob store and they just take
up space in the filesystem that won't be reclaimed when models are
destroyed or migrated off the controller.

Part of fixing: https://bugs.launchpad.net/juju/+bug/1579976