### PR TITLE
csclient/params: put more stuff in upload response

### DIFF
--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -450,9 +450,24 @@ type SetAuthCookie struct {
 	Macaroons macaroon.Slice
 }
 
-// UploadIdResponse holds the upload id response from a POST request to /upload.
-type UploadIdResponse struct {
+// NewUploadResponse holds the response from a POST request to /upload.
+type NewUploadResponse struct {
+	// UploadId holds the id of the upload.
 	UploadId string
+
+	// Expires holds when the upload id expires.
+	Expires time.Time
+
+	// MinPartSize holds the minimum size of a part that may
+	// be uploaded (not including the last part).
+	MinPartSize int64
+
+	// MaxPartSize holds the maximum size of a part that may
+	// be uploaded.
+	MaxPartSize int64
+
+	// MaxParts holds the maximum number of parts.
+	MaxParts int
 }
 
 // Parts holds a list of all the parts that are required by a multipart


### PR DESCRIPTION
We want the client to have information about part sizes, etc
when doing multipart uploads. Also change the type name
because it now holds more than just an upload id.