### PR TITLE
internal/iomon: new package

### DIFF
--- a/internal/iomon/iomon.go
+++ b/internal/iomon/iomon.go
@@ -1,0 +1,140 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package iomon
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	
+	"github.com/juju/utils/clock"
+
+	tomb "gopkg.in/tomb.v2"
+)
+
+const DefaultUpdateInterval = time.Second
+
+// Monitor holds a monitor that continually updates
+// a status value with the current progress of some
+// long IO operation.
+type Monitor struct {
+	tomb tomb.Tomb
+
+	p       Params
+
+	currentStatus Status
+
+	mu      sync.Mutex
+	current int64
+}
+
+// Params holds the parameters for creating a new monitor.
+type Params struct {
+	// Size holds the total size of the transfer.
+	Size int64
+
+	// Setter is used to set the current status of
+	// the transfer.
+	Setter StatusSetter
+
+	// UpdateInterval controls how often a status update will be
+	// sent. It it's zero, DefaultUpdateInterval will be used.
+	UpdateInterval time.Duration
+
+	// Clock is used as a source of timing information.
+	// If it is nil, the global time will be used.
+	Clock clock.Clock
+}
+
+// New returns a new running monitor
+// using the given parameters. The Monitor
+// should be stopped when the transfer is complete.
+func New(p Params) *Monitor {
+	if p.UpdateInterval == 0 {
+		p.UpdateInterval = DefaultUpdateInterval
+	}
+	if p.Clock == nil {
+		p.Clock = clock.WallClock
+	}
+	m := &Monitor{
+		p: p,
+	}
+	m.tomb.Go(m.run)
+	return m
+}
+
+// Kill kills the monitor but does not wait for it to exit.
+func (m *Monitor) Kill() {
+	m.tomb.Kill(nil)
+}
+
+// Wait waits for the monitor to exit. When this
+// returns, SetStatus will no longer be called.
+func (m *Monitor) Wait() error {
+	m.tomb.Wait()
+	return nil
+}
+
+func (m *Monitor) Update(current int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.current = current
+}
+
+// Status indicates the current status of the I/O transfer.
+type Status struct {
+	Current int64
+	Total   int64
+
+	// TODO add rate, expected time
+}
+
+// StatusSetter is used to indicate the current progress status.
+type StatusSetter interface {
+	SetStatus(s Status)
+}
+
+func (m *Monitor) run() error {
+	for {
+		m.setStatus()
+		select {
+		case <-m.p.Clock.After(m.p.UpdateInterval):
+		case <-m.tomb.Dying():
+			// Always set the final status when finishing.
+			m.setStatus()
+			return nil
+		}
+	}
+}
+
+func (m *Monitor) setStatus() {
+	m.mu.Lock()
+	current := m.current
+	m.mu.Unlock()
+	status := Status{
+		Current: current,
+		Total:   m.p.Size,
+	}
+	if status != m.currentStatus {
+		m.p.Setter.SetStatus(status)
+		m.currentStatus = status
+	}
+}
+
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+)
+
+func FormatByteCount(n int64) string {
+	switch {
+	case n < 10*MiB:
+		return fmt.Sprintf("%.0fKiB", float64(n)/KiB)
+	case n < 10*GiB:
+		return fmt.Sprintf("%.1fMiB", float64(n)/MiB)
+	default:
+		return fmt.Sprintf("%.1fGiB", float64(n)/GiB)
+	}
+}

--- a/internal/iomon/iomon_test.go
+++ b/internal/iomon/iomon_test.go
@@ -1,0 +1,98 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package iomon_test
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charmrepo.v2-unstable/internal/iomon"
+)
+
+type iomonSuite struct{}
+
+var _ = gc.Suite(&iomonSuite{})
+
+func (*iomonSuite) TestMonitor(c *gc.C) {
+	setterCh := make(statusSetter)
+	t0 := time.Now()
+	clock := testing.NewClock(t0)
+	m := iomon.New(iomon.Params{
+		Size:           1000,
+		Setter:         setterCh,
+		UpdateInterval: time.Second,
+		Clock:          clock,
+	})
+	c.Assert(setterCh.wait(c), jc.DeepEquals, iomon.Status{
+		Current: 0,
+		Total:   1000,
+	})
+	clock.Advance(time.Second)
+	// Nothing changed, so no status should be sent.
+	setterCh.expectNothing(c)
+	// Calling update should not trigger a status send.
+	m.Update(500)
+	setterCh.expectNothing(c)
+	clock.Advance(time.Second)
+	c.Assert(setterCh.wait(c), jc.DeepEquals, iomon.Status{
+		Current: 500,
+		Total:   1000,
+	})
+	m.Update(700)
+	m.Kill()
+	// One last status update should be sent when it's killed.
+	c.Assert(setterCh.wait(c), jc.DeepEquals, iomon.Status{
+		Current: 700,
+		Total:   1000,
+	})
+	m.Wait()
+	clock.Advance(10 * time.Second)
+	setterCh.expectNothing(c)
+}
+
+var formatByteCountTests = []struct {
+	n      int64
+	expect string
+}{
+	{0, "0KiB"},
+	{2567, "3KiB"},
+	{9876 * 1024, "9876KiB"},
+	{10 * 1024 * 1024, "10.0MiB"},
+	{20 * 1024 * 1024 * 1024, "20.0GiB"},
+	{55068359375, "51.3GiB"},
+}
+
+func (*iomonSuite) TestFormatByteCount(c *gc.C) {
+	for i, test := range formatByteCountTests {
+		c.Logf("test %d: %v", i, test.n)
+		c.Assert(iomon.FormatByteCount(test.n), gc.Equals, test.expect)
+	}
+}
+
+type statusSetter chan iomon.Status
+
+func (ch statusSetter) wait(c *gc.C) iomon.Status {
+	select {
+	case s := <-ch:
+		return s
+	case <-time.After(5 * time.Second):
+		c.Fatalf("timed out waiting for status")
+		panic("unreachable")
+	}
+}
+
+func (ch statusSetter) expectNothing(c *gc.C) {
+	select {
+	case s := <-ch:
+		c.Fatalf("unexpected status received %#v", s)
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+func (ch statusSetter) SetStatus(s iomon.Status) {
+	ch <- s
+}

--- a/internal/iomon/package_test.go
+++ b/internal/iomon/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package iomon_test
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This will provide the mechanism behind printing I/O progress
updates to the command line. It's designed so that we can update
it with current transfer rate at a future date, and also so that
it could be externally reusable.