### PR TITLE
csclient/params: resumable uploads

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -263,11 +263,17 @@ type Progress interface {
 // given file, which must have the given size. If progress is not nil, it will
 // be called to inform the caller of the progress of the upload.
 func (c *Client) UploadResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, progress Progress) (revision int, err error) {
+	return c.ResumeUploadResource("", id, name, path, file, size, progress)
+}
+
+// ResumeUploadResource is like UploadResource except that if uploadId is non-empty,
+// it specifies the id of an existing upload to resume.
+func (c *Client) ResumeUploadResource(uploadId string, id *charm.URL, name, path string, file io.ReaderAt, size int64, progress Progress) (revision int, err error) {
 	if progress == nil {
 		progress = noProgress{}
 	}
 	if size >= minMultipartUploadSize {
-		return c.uploadMultipartResource(id, name, path, file, size, progress)
+		return c.uploadMultipartResource(id, name, path, file, size, uploadId, progress)
 	}
 	return c.uploadSinglePartResource(id, name, path, file, size, progress)
 }
@@ -310,32 +316,69 @@ func (c *Client) uploadSinglePartResource(id *charm.URL, name, path string, file
 	return result.Revision, nil
 }
 
-func (c *Client) uploadMultipartResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, progress Progress) (revision int, err error) {
-	// Create the upload.
-	var resp params.NewUploadResponse
-	if err := c.doWithResponse("POST", "/upload", nil, &resp); err != nil {
-		if errgo.Cause(err) == params.ErrNotFound {
-			// An earlier version of the API - try single part upload even though it's big.
-			return c.uploadSinglePartResource(id, name, path, file, size, progress)
+func (c *Client) uploadMultipartResource(id *charm.URL, name, path string, file io.ReaderAt, size int64, uploadId string, progress Progress) (int, error) {
+	var expires time.Time
+	var maxParts int
+	var maxPartSize, minPartSize int64
+	var uploadedParts *[]params.Part
+	if len(uploadId) == 0 {
+		// Create the upload.
+		var resp params.NewUploadResponse
+		if err := c.doWithResponse("POST", "/upload", nil, &resp); err != nil {
+			if errgo.Cause(err) == params.ErrNotFound {
+				// An earlier version of the API - try single part upload even though it's big.
+				return c.uploadSinglePartResource(id, name, path, file, size, progress)
+			}
+			return 0, errgo.Mask(err)
 		}
-		return 0, errgo.Mask(err)
+		uploadId = resp.UploadId
+		expires = resp.Expires
+		maxParts = resp.MaxParts
+		minPartSize = resp.MinPartSize
+		maxPartSize = resp.MaxPartSize
+	} else {
+		var resp params.UploadInfoResponse
+		if err := c.doWithResponse("GET", "/upload/"+uploadId, nil, &resp); err != nil {
+			if err != nil {
+				return 0, errgo.Mask(err, errgo.Is(params.ErrNotFound))
+			}
+			return 0, errgo.Mask(err)
+		}
+		expires = resp.Expires
+		maxParts = resp.MaxParts
+		minPartSize = resp.MinPartSize
+		maxPartSize = resp.MaxPartSize
+		uploadedParts = &resp.Parts.Parts
 	}
-	uploadId := resp.UploadId
-	progress.Start(uploadId, resp.Expires)
+	progress.Start(uploadId, expires)
 	// Calculate the part size, but round up so that we have
 	// enough parts to cover the remainder at the end.
-	partSize := (size + int64(resp.MaxParts) - 1) / int64(resp.MaxParts)
-	if partSize > resp.MaxPartSize {
-		return 0, errgo.Newf("resource too big (allowed %.3fGB)", float64(resp.MaxPartSize)*float64(resp.MaxParts)/1e9)
+	partSize := (size + int64(maxParts) - 1) / int64(maxParts)
+	if partSize > maxPartSize {
+		return 0, errgo.Newf("resource too big (allowed %.3fGB)", float64(maxPartSize)*float64(maxParts)/1e9)
 	}
-	if partSize < resp.MinPartSize {
-		partSize = resp.MinPartSize
+	if partSize < minPartSize {
+		partSize = minPartSize
 	}
+	revision, err := c.uploadParts(id, name, path, uploadId, partSize, uploadedParts, file, size, progress)
+	if err != nil {
+		return 0, errgo.Mask(err)
+	}
+	return revision, nil
+}
+
+func (c *Client) uploadParts(id *charm.URL, name, path string, uploadId string, partSize int64, uploadedParts *[]params.Part, file io.ReaderAt, size int64, progress Progress) (int, error) {
 	var parts params.Parts
+	if uploadedParts != nil {
+		parts.Parts = *uploadedParts
+	}
 	for i, p0 := 0, int64(0); ; i, p0 = i+1, p0+partSize {
 		p1 := p0 + partSize
 		if p1 > size {
 			p1 = size
+		}
+		if len(parts.Parts) > i && parts.Parts[i].Complete {
+			continue
 		}
 		// TODO concurrent part upload?
 		hash, err := c.uploadPart(uploadId, i, file, p0, p1, progress)
@@ -343,7 +386,8 @@ func (c *Client) uploadMultipartResource(id *charm.URL, name, path string, file 
 			return 0, errgo.Mask(err)
 		}
 		parts.Parts = append(parts.Parts, params.Part{
-			Hash: hash,
+			Hash:     hash,
+			Complete: true,
 		})
 		if p1 >= size {
 			break

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -1389,7 +1389,7 @@ func (s *suite) TestPutMultiError(c *gc.C) {
 	cause := cause0.(*params.Error)
 	// Instead, we get just the "multiple errors" code.
 	c.Assert(cause.ErrorInfo(), jc.DeepEquals, map[string]*params.Error{
-		"~charmers/utopic/xxx-42": &params.Error{
+		"~charmers/utopic/xxx-42": {
 			Message: `no matching charm or bundle for cs:~charmers/utopic/xxx-42`,
 			Code:    params.ErrNotFound,
 		},
@@ -1882,6 +1882,64 @@ func (s *suite) TestUploadTooLargeResource(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `resource too big \(allowed \d+\.\d{3}GB\)`)
 }
 
+type errorReaderAt struct {
+	reader io.ReaderAt
+}
+
+func (e errorReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	if off > 0 {
+		return 0, errgo.New("stop here")
+	}
+	return e.reader.ReadAt(p, off)
+}
+
+func (s *suite) TestResumeUploadResource(c *gc.C) {
+	s.PatchValue(csclient.MinMultipartUploadSize, int64(10))
+
+	ch := charmtesting.NewCharmMeta(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"resname": {
+				Name: "resname",
+				Path: "foo",
+			},
+		},
+	})
+	url, err := s.client.UploadCharm(charm.MustParseURL("cs:~who/trusty/mysql"), ch)
+	c.Assert(err, gc.IsNil)
+
+	content := "abcdefghijklmnopqrstuvwxyz"
+	// Upload the resource.
+	progress := &testProgress{c: c}
+	e := &errorReaderAt{
+		reader: strings.NewReader(content),
+	}
+	rev, err := s.client.UploadResource(url, "resname", "data", e, int64(len(content)), progress)
+	c.Assert(err, gc.ErrorMatches, "cannot read resource: stop here")
+	rev, err = s.client.ResumeUploadResource(progress.uploadId, url, "resname", "data", strings.NewReader(content), int64(len(content)), progress)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(rev, gc.Equals, 0)
+
+	// Check that we can download it OK.
+	getResult, err := s.client.GetResource(url, "resname", 0)
+	c.Assert(err, jc.ErrorIsNil)
+	defer getResult.Close()
+
+	expectHash := fmt.Sprintf("%x", sha512.Sum384([]byte(content)))
+	c.Assert(getResult.Hash, gc.Equals, expectHash)
+
+	gotData, err := ioutil.ReadAll(getResult)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(gotData), gc.Equals, content)
+	c.Assert(progress.Collected, jc.DeepEquals, []interface{}{
+		startProgress{},
+		transferredProgress{10},
+		startProgress{},
+		transferredProgress{20},
+		transferredProgress{26},
+		finalizingProgress{},
+	})
+}
+
 func (s *suite) TestListResources(c *gc.C) {
 	ch := charmtesting.NewCharmMeta(&charm.Meta{
 		Resources: map[string]resource.Meta{
@@ -2129,6 +2187,7 @@ func (m *termsDischarger) thirdPartyChecker(_ *http.Request, cond, args string) 
 type testProgress struct {
 	c         *gc.C
 	Collected []interface{}
+	uploadId  string
 }
 
 type startProgress struct {
@@ -2149,6 +2208,7 @@ func (p *testProgress) Start(uploadId string, expires time.Time) {
 	p.Collected = append(p.Collected, startProgress{})
 	p.c.Assert(uploadId, gc.NotNil)
 	p.c.Assert(expires.After(time.Now()), gc.Equals, true)
+	p.uploadId = uploadId
 }
 
 func (p *testProgress) Transferred(total int64) {

--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -457,24 +457,8 @@ type SetAuthCookie struct {
 }
 
 // NewUploadResponse holds the response from a POST request to /upload.
-type NewUploadResponse struct {
-	// UploadId holds the id of the upload.
-	UploadId string
-
-	// Expires holds when the upload id expires.
-	Expires time.Time
-
-	// MinPartSize holds the minimum size of a part that may
-	// be uploaded (not including the last part).
-	MinPartSize int64
-
-	// MaxPartSize holds the maximum size of a part that may
-	// be uploaded.
-	MaxPartSize int64
-
-	// MaxParts holds the maximum number of parts.
-	MaxParts int
-}
+// TODO remove this when the charmstore code no longer requires it.
+type NewUploadResponse UploadInfoResponse
 
 // Parts holds a list of all the parts that are required by a multipart
 // upload, as required by a PUT request to /upload/$upload-id.
@@ -488,6 +472,9 @@ type Part struct {
 	Hash string
 	// Size holds the size of the part.
 	Size int64
+	// Offset holds the offset of the part from the start
+	// of the file.
+	Offset int64
 	// Complete holds whether the part has been
 	// successfully uploaded.
 	Complete bool
@@ -501,6 +488,9 @@ type FinishUploadResponse struct {
 
 // UploadInfoResponse holds the response to a get /upload/upload-id request.
 type UploadInfoResponse struct {
+	// UploadId holds the id of the upload.
+	UploadId string
+
 	// Parts holds all the known parts of the upload.
 	// Parts that haven't been uploaded yet will have nil
 	// elements.
@@ -508,4 +498,15 @@ type UploadInfoResponse struct {
 
 	// Expires holds when the upload will expire.
 	Expires time.Time
+
+	// MinPartSize holds the minimum size of a part that may
+	// be uploaded (not including the last part).
+	MinPartSize int64
+
+	// MaxPartSize holds the maximum size of a part that may
+	// be uploaded.
+	MaxPartSize int64
+
+	// MaxParts holds the maximum number of parts.
+	MaxParts int
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -34,7 +34,7 @@ gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:
 gopkg.in/goose.v2	git	455416024500800de8dadbcacfa22681b6bb818d	2017-09-04T09:17:38Z
 gopkg.in/httprequest.v1	git	3531529dedf047a744dd77f5262515aefff8cd48	2018-03-19T12:54:57Z
 gopkg.in/juju/charm.v6	git	e03b52c17fcc23dd3154fdda6cbd357c6ded1f01	2017-11-14T08:45:40Z
-gopkg.in/juju/charmstore.v5	git	cc702cbe79a66f65f5ec4f2381f2e34206c8ad06	2018-05-11T14:03:37Z
+gopkg.in/juju/charmstore.v5	git	779b52f4fcf58f4f50ab75f6e94492caeb7ab572	2018-05-11T14:58:13Z
 gopkg.in/juju/jujusvg.v3	git	6f7342099e20c84f560bd9fc8afe96ff7486613e	2017-11-14T17:07:01Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z
 gopkg.in/juju/worker.v1	git	8b18096b52dc89d0160eea0a6484175f2b80aa0d	2016-10-03T16:17:01Z


### PR DESCRIPTION
This adds the capability to resume an upload from scratch.
The code does not work against the old version of the charm store
so we depend temporarily on a new version of the charm store
in a feature branch.