### PR TITLE
csclient/params: resumable uploads

### DIFF
--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -449,24 +449,8 @@ type SetAuthCookie struct {
 }
 
 // NewUploadResponse holds the response from a POST request to /upload.
-type NewUploadResponse struct {
-	// UploadId holds the id of the upload.
-	UploadId string
-
-	// Expires holds when the upload id expires.
-	Expires time.Time
-
-	// MinPartSize holds the minimum size of a part that may
-	// be uploaded (not including the last part).
-	MinPartSize int64
-
-	// MaxPartSize holds the maximum size of a part that may
-	// be uploaded.
-	MaxPartSize int64
-
-	// MaxParts holds the maximum number of parts.
-	MaxParts int
-}
+// TODO remove this when the charmstore code no longer requires it.
+type NewUploadResponse UploadInfoResponse
 
 // Parts holds a list of all the parts that are required by a multipart
 // upload, as required by a PUT request to /upload/$upload-id.
@@ -480,6 +464,9 @@ type Part struct {
 	Hash string
 	// Size holds the size of the part.
 	Size int64
+	// Offset holds the offset of the part from the start
+	// of the file.
+	Offset int64
 	// Complete holds whether the part has been
 	// successfully uploaded.
 	Complete bool
@@ -493,6 +480,9 @@ type FinishUploadResponse struct {
 
 // UploadInfoResponse holds the response to a get /upload/upload-id request.
 type UploadInfoResponse struct {
+	// UploadId holds the id of the upload.
+	UploadId string
+
 	// Parts holds all the known parts of the upload.
 	// Parts that haven't been uploaded yet will have nil
 	// elements.
@@ -500,4 +490,15 @@ type UploadInfoResponse struct {
 
 	// Expires holds when the upload will expire.
 	Expires time.Time
+
+	// MinPartSize holds the minimum size of a part that may
+	// be uploaded (not including the last part).
+	MinPartSize int64
+
+	// MaxPartSize holds the maximum size of a part that may
+	// be uploaded.
+	MaxPartSize int64
+
+	// MaxParts holds the maximum number of parts.
+	MaxParts int
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:1
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
 github.com/matttproud/golang_protobuf_extensions	git	c12348ce28de40eed0136aa2b644d0ee0650e56c	2016-04-24T11:30:07Z
-github.com/prometheus/client_golang	git	c5b7fccd204277076155f10851dad72b76a49317	2016-08-17T15:48:24Z
+github.com/prometheus/client_golang	git	575f371f7862609249a1be4c9145f429fe065e32	2016-11-24T15:57:32Z
 github.com/prometheus/client_model	git	99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c	2017-11-17T10:05:41Z
 github.com/prometheus/common	git	6fb6fce6f8b75884b92e1889c150403fc0872c5e	2018-02-28T09:25:48Z
 github.com/prometheus/procfs	git	d274e363d5759d1c916232217be421f1cc89c5fe	2018-02-28T15:07:32Z
@@ -33,9 +33,9 @@ gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:
 gopkg.in/goose.v2	git	4dc44b23a313a8a3e4051e7ee568a954a8cb3385	2018-02-08T12:05:40Z
 gopkg.in/httprequest.v1	git	3531529dedf047a744dd77f5262515aefff8cd48	2018-03-19T12:54:57Z
 gopkg.in/juju/charm.v6	git	96786fc3f8695207515eb6be307ff37901a7254f	2018-01-19T23:10:43Z
-gopkg.in/juju/charmrepo.v3	git	7f799297ba8d526feb52630477bd44e71037f92e	2018-04-11T22:45:32Z
-gopkg.in/juju/charmstore.v5	git	b247403557f8622e3ea64bd31e9ad569379daf08	2018-05-01T08:35:10Z
-gopkg.in/juju/idmclient.v1	git	e35a92586d090fc2675f1db551ebae4184a43d64	2017-11-10T11:12:44Z
+gopkg.in/juju/charmrepo.v3	git	3d036d99fb5c12f98e017093a4a7c85433ac9578	2018-05-11T16:22:30Z
+gopkg.in/juju/charmstore.v5	git	1920a2dc155027fb194122b5487a8435b8480355	2018-05-16T16:11:04Z
+gopkg.in/juju/idmclient.v1	git	203d20774ce8aeaa6f662ee0b48f8cb5bc0816a1	2018-03-20T16:18:56Z
 gopkg.in/juju/jujusvg.v3	git	6f7342099e20c84f560bd9fc8afe96ff7486613e	2017-11-14T17:07:01Z
 gopkg.in/juju/names.v2	git	54f00845ae470a362430a966fe17f35f8784ac92	2017-11-13T11:20:47Z
 gopkg.in/juju/worker.v1	git	6965b9d826717287bb002e02d1fd4d079978083e	2017-03-08T00:24:58Z
@@ -44,7 +44,7 @@ gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf
 gopkg.in/macaroon.v2	git	bed2a428da6e56d950bed5b41fcbae3141e5b0d0	2017-10-17T15:30:37Z
 gopkg.in/macaroon.v2-unstable	git	66ab28d0d56f39a383f7cf5cf3ac9a4e9ab32865	2018-03-09T13:12:17Z
 gopkg.in/mgo.v2	git	3f83fa5005286a7fe593b055f0d7771a7dce4655	2016-08-18T02:01:20Z
-gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
+gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/tomb.v2	git	d5d1b5820637886def9eef33e03a27a9f166942c	2016-12-08T15:16:19Z
 gopkg.in/yaml.v2	git	7f97868eec74b32b0982dd158a51a446d1da7eb5	2018-02-23T19:12:37Z


### PR DESCRIPTION
This is an exact copy of PR #128, targeted at the v4 branch instead of v3.

This adds the capability to resume an upload from scratch.
The code does not work against the old version of the charm store
so we depend temporarily on a new version of the charm store
in a feature branch.
