### PR TITLE
csclient: cope better with upload after partial resume

### DIFF
--- a/csclient/params/params.go
+++ b/csclient/params/params.go
@@ -459,17 +459,24 @@ type Parts struct {
 }
 
 // Part represents one part of a multipart blob.
+// When a set of parts is returned from an upload
+// query GET, those with zero sizes should
+// be considered non-existent.
 type Part struct {
 	// Hash holds the SHA384 hash of the part.
-	Hash string
+	Hash string `json:",omitempty"`
 	// Size holds the size of the part.
-	Size int64
+	Size int64 `json:",omitempty"`
 	// Offset holds the offset of the part from the start
 	// of the file.
-	Offset int64
+	Offset int64 `json:",omitempty"`
 	// Complete holds whether the part has been
 	// successfully uploaded.
-	Complete bool
+	Complete bool `json:",omitempty"`
+}
+
+func (p Part) Valid() bool {
+	return p.Size > 0
 }
 
 // FinishUploadResponse holds the response to a put /upload/upload-id/part-number request.


### PR DESCRIPTION
The code as is does not cope with parts that have been omitted.
As we want to be able to do concurrent upload in the future,
we can't always rely on sequential part upload, so we we write
code to cope with arbitrary previously uploaded parts.
