### PR TITLE
csclient: return resource size

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -655,6 +655,7 @@ func (c *Client) Publish(id *charm.URL, channels []params.Channel, resources map
 // It must be closed after use.
 type ResourceData struct {
 	io.ReadCloser
+	Size int64
 	Hash string
 }
 
@@ -695,6 +696,7 @@ func (c *Client) GetResource(id *charm.URL, name string, revision int) (result R
 
 	return ResourceData{
 		ReadCloser: resp.Body,
+		Size:       resp.ContentLength,
 		Hash:       hash,
 	}, nil
 }

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -2547,6 +2547,8 @@ func assertGetResource(c *gc.C, client *csclient.Client, url *charm.URL, resourc
 	c.Assert(err, jc.ErrorIsNil)
 	defer getResult.Close()
 
+	c.Check(getResult.Size, gc.Equals, int64(len(expectData)))
+
 	gotData, err := ioutil.ReadAll(getResult)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(gotData), gc.Equals, expectData)


### PR DESCRIPTION
We'd like to know how big a resource is before downloading it.