### PR TITLE
csclient: allow upload of zero-length resources

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -369,6 +369,11 @@ func (c *Client) uploadSinglePartResource(info *uploadInfo) (revision int, err e
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = info.size
+	if info.size == 0 {
+		// Setting body to nil is the only way to make sure that
+		// an explicit 0 Content-Length header is set.
+		req.Body = nil
+	}
 	path := fmt.Sprintf("/%s/resource/%s", info.id.Path(), info.resourceName)
 	if info.revision != -1 {
 		path += fmt.Sprintf("/%d", info.revision)

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -1700,6 +1700,28 @@ func (s *suite) TestUploadResource(c *gc.C) {
 	}
 }
 
+func (s *suite) TestUploadEmptyResource(c *gc.C) {
+	ch := charmtesting.NewCharmMeta(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"resname": {
+				Name: "resname",
+				Path: "foo.zip",
+			},
+		},
+	})
+	url, err := s.client.UploadCharm(charm.MustParseURL("cs:~who/trusty/mysql"), ch)
+	c.Assert(err, gc.IsNil)
+
+	// Upload the resource.
+	data := ""
+	rev, err := s.client.UploadResource(url, "resname", "data.zip", strings.NewReader(data), int64(len(data)), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rev, gc.Equals, 0)
+
+	// Check that we can download it OK.
+	assertGetResource(c, s.client, url, "resname", 0, data)
+}
+
 func (s *suite) TestUploadResourceWithRevision(c *gc.C) {
 	ch := charmtesting.NewCharmMeta(&charm.Meta{
 		Resources: map[string]resource.Meta{
@@ -1714,6 +1736,28 @@ func (s *suite) TestUploadResourceWithRevision(c *gc.C) {
 
 	// Upload the resource.
 	data := "boo!"
+	rev, err := s.client.UploadResourceWithRevision(url, "resname", 13, "data.zip", strings.NewReader(data), int64(len(data)), nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rev, gc.Equals, 13)
+
+	// Check that we can download it OK.
+	assertGetResource(c, s.client, url, "resname", 13, data)
+}
+
+func (s *suite) TestUploadEmptyResourceWithRevision(c *gc.C) {
+	ch := charmtesting.NewCharmMeta(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"resname": {
+				Name: "resname",
+				Path: "foo.zip",
+			},
+		},
+	})
+	url, err := s.client.UploadCharm(charm.MustParseURL("cs:~who/trusty/mysql"), ch)
+	c.Assert(err, gc.IsNil)
+
+	// Upload the resource.
+	data := ""
 	rev, err := s.client.UploadResourceWithRevision(url, "resname", 13, "data.zip", strings.NewReader(data), int64(len(data)), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rev, gc.Equals, 13)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/CanonicalLtd/omniutils v0.0.0-20180607151646-ed3ed7dca482 h1:z73GY/40
 github.com/CanonicalLtd/omniutils v0.0.0-20180607151646-ed3ed7dca482/go.mod h1:5V82xWN3v1yBIydXmOEoIi8AEc6eD+anbxaEiYPyB6k=
 github.com/ajstarks/svgo v0.0.0-20141004211159-89e3ac64b5b3 h1:T8jEYyGBYGpEfGFizvl7BB/uyxtVEnMz2M8+GqsCGuE=
 github.com/ajstarks/svgo v0.0.0-20141004211159-89e3ac64b5b3/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/cloud-green/monitoring v0.0.0-20171127132220-666e3beca3cb h1:tbMTJZL4JD5nVvk6xNtD2DovF4Hqzn84yTSx4su2HNs=
 github.com/cloud-green/monitoring v0.0.0-20171127132220-666e3beca3cb/go.mod h1:WGFh0Idi1w3qgbdg5FiPBBf/QhvwwRtqvgG/nYZ+JRs=
@@ -11,6 +12,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda h1:NyywMz59neOoVRFDz+ccfKWxn784fiHMDnZSy6T+JXY=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang/protobuf v1.0.0 h1:lsek0oXi8iFE9L+EXARyHIjU5rlWIhhTkjDz3vHhWWQ=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299 h1:K9nBHQ3UNqg/HhZkQnGG2AE4YxDyNmGS9FFT2gGegLQ=
@@ -20,9 +22,13 @@ github.com/juju/collections v0.0.0-20180516022642-90152009b5f3/go.mod h1:Ep+c0vn
 github.com/juju/errors v0.0.0-20170703010042-c7d06af17c68/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177 h1:UliPGoJWlIH3IkkFqnPy/xYF/2tkTRTZhMt8/CwGUvw=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
+github.com/juju/gojsonpointer v0.0.0-20150204194629-afe8b77aa08f h1:QzpKmMsaP06HVZnYNlcy1CLIXPytsj2NuzfCHitxuus=
 github.com/juju/gojsonpointer v0.0.0-20150204194629-afe8b77aa08f/go.mod h1:IsZAJBSicjtWD22i4pWwfl0xgijIeBEOIJYwgM9bpqw=
+github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXmVPTML75YvFBOiaNj4ZiCZgKVnkRQ06d3w=
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
+github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2 h1:VqIDC6dRE0C7wEtTdT6zx2zP5omaoJiZXp2g/dBHRcE=
 github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
+github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v0.0.0-20161006150909-266fd1e9debf h1:+qtbaX4Z0htlSnO91dEAOa4BGBVv6ZhbLS+4dy+ZuDQ=
 github.com/juju/httprequest v0.0.0-20161006150909-266fd1e9debf/go.mod h1:ogcnuLPnijli/VAQT3/CU+2EdSTVsGRfpWTV/VY457I=
@@ -46,11 +52,13 @@ github.com/juju/utils v0.0.0-20180619112806-c746c6e86f4f/go.mod h1:6/KLg8Wz/y2KV
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305 h1:lQxPJ1URr2fjsKnJRt/BxiIxjLt9IKGvS+0injMHbag=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
+github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4 h1:go1FDIXkFL8AUWgJ7B68rtFWCidyrMfZH9x3xwFK74s=
 github.com/juju/webbrowser v0.0.0-20160309143629-54b8c57083b4/go.mod h1:G6PCelgkM6cuvyD10iYJsjLBsSadVXtJ+nBxFAxE2BU=
 github.com/juju/xml v0.0.0-20150413131121-eb759a627588 h1:sr4LCVUJTRlQxK/pBTUihgdGsUvJ6NVsiszop4AJkCw=
 github.com/juju/xml v0.0.0-20150413131121-eb759a627588/go.mod h1:RnnCV6b9HzujjOLGRpqvZc8INbwtBzZlhbCj5R9F1vw=
 github.com/juju/zip v0.0.0-20160205105221-f6b1e93fa2e2 h1:McU3wXjBrKfJcOt2Pali5qEir9NLrqOh4EECzdWHknM=
 github.com/juju/zip v0.0.0-20160205105221-f6b1e93fa2e2/go.mod h1:3mJ64RiWU2x9U6IigvcoVLra6LZQTOwMuHpk02OtOJc=
+github.com/julienschmidt/httprouter v0.0.0-20151013225520-77a895ad01eb h1:a8sYyruWLyKeMay8GPF+nwZ36xT7A0oNyn68Q6wJ5cc=
 github.com/julienschmidt/httprouter v0.0.0-20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -66,11 +74,13 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_golang v0.0.0-20161124155732-575f371f7862/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.0.0-20180319131721-d49167c4b9f3 h1:IlkKMWpcBADSCBBkzSukNTFPfhEV+3VyGN4b0Wc2IUA=
 github.com/prometheus/client_golang v0.0.0-20180319131721-d49167c4b9f3/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5 h1:cLL6NowurKLMfCeQy4tIeph12XNQWgANCNvdyrOYKV4=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180228092548-6fb6fce6f8b7 h1:M7FNIWkkGynttTfTsqQSWnhqzNS5ubqaXSJT7oGDfgI=
 github.com/prometheus/common v0.0.0-20180228092548-6fb6fce6f8b7/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180228150732-d274e363d575 h1:4Zb2avblo3TR4qHIkHe0HDHiGnV2/a3SIAHe91/6tiM=
 github.com/prometheus/procfs v0.0.0-20180228150732-d274e363d575/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -127,6 +137,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV4fzYhNBql77zY0ykqs=
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.1.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=


### PR DESCRIPTION
When ContentLength is zero, net/http treats the content length
as unknown unless req.Body is nil, which meant that we'd
get an error when uploading a resource because the charmstore
server requires an explicit Content-Length.