### PR TITLE
Add charmstore method to resolve charm/bundles with a preferred channel

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -223,11 +223,18 @@ func (s *CharmStore) Resolve(ref *charm.URL) (*charm.URL, []string, error) {
 // ResolveWithChannel does the same thing as Resolve() but also returns
 // the best channel to use.
 func (s *CharmStore) ResolveWithChannel(ref *charm.URL) (*charm.URL, params.Channel, []string, error) {
+	return s.ResolveWithPreferredChannel(ref, s.client.Channel())
+}
+
+// ResolveWithPreferredChannel does the same thing as ResolveWithChannel() but
+// allows callers to specify a preferred channel to use.
+func (s *CharmStore) ResolveWithPreferredChannel(ref *charm.URL, channel params.Channel) (*charm.URL, params.Channel, []string, error) {
 	var result struct {
 		Id              params.IdResponse
 		SupportedSeries params.SupportedSeriesResponse
 		Published       params.PublishedResponse
 	}
+
 	if _, err := s.client.Meta(ref, &result); err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
 			// Make a prettier error message for the user.
@@ -242,11 +249,23 @@ func (s *CharmStore) ResolveWithChannel(ref *charm.URL) (*charm.URL, params.Chan
 		}
 		return nil, params.NoChannel, nil, errgo.NoteMask(err, fmt.Sprintf("cannot resolve charm URL %q", ref), errgo.Any)
 	}
+
+	// If no preferredChannel is specified then we should use the (optional)
+	// csclient channel value as our preferredChannel.
+	if channel == params.NoChannel {
+		channel = s.client.Channel()
+	}
+
+	// Validate requested channel.
+	if _, isValid := params.ValidChannels[channel]; !isValid && channel != params.NoChannel {
+		return nil, params.NoChannel, nil, errgo.WithCausef(nil, params.ErrNotFound, "cannot resolve URL %q: %q is not a valid channel", ref, channel)
+	}
+
 	// TODO(ericsnow) Get this directly from the API. It has high risk
 	// of getting stale. Perhaps add params.PublishedResponse.BestChannel
 	// or, less desireably, have params.PublishedResponse.Info be
 	// priority-ordered.
-	channel := bestChannel(s.client, result.Published.Info)
+	channel = bestChannel(s.client, result.Published.Info, channel)
 	return result.Id.Id, channel, result.SupportedSeries.SupportedSeries, nil
 }
 
@@ -255,10 +274,9 @@ func (s *CharmStore) ResolveWithChannel(ref *charm.URL) (*charm.URL, params.Chan
 //
 // Note that this is equivalent to code on the server side.
 // See ReqHandler.entityChannel in internal/v5/auth.go.
-func bestChannel(client *csclient.Client, published []params.PublishedInfo) params.Channel {
-	explicitChannel := client.Channel()
-	if explicitChannel != params.NoChannel {
-		return explicitChannel
+func bestChannel(client *csclient.Client, published []params.PublishedInfo, preferredChannel params.Channel) params.Channel {
+	if preferredChannel != params.NoChannel {
+		return preferredChannel
 	}
 	if len(published) == 0 {
 		return params.UnpublishedChannel

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -485,62 +485,62 @@ func (s *charmStoreRepoSuite) TestResolveWithChannelEquivalentToResolve(c *gc.C)
 	}
 }
 
-func (s *charmStoreRepoSuite) TestResolveWithChannel(c *gc.C) {
-	tests := []struct {
-		clientChannel params.Channel
-		published     []params.Channel
-		expected      params.Channel
-	}{{
-		clientChannel: params.StableChannel,
-		expected:      params.StableChannel,
-	}, {
-		clientChannel: params.EdgeChannel,
-		expected:      params.EdgeChannel,
-	}, {
-		clientChannel: params.UnpublishedChannel,
-		expected:      params.UnpublishedChannel,
-	}, {
-		clientChannel: params.NoChannel,
-		expected:      params.UnpublishedChannel,
-	}, {
-		published: []params.Channel{params.StableChannel},
-		expected:  params.StableChannel,
-	}, {
-		published: []params.Channel{params.EdgeChannel},
-		expected:  params.EdgeChannel,
-	}, {
-		published: []params.Channel{params.StableChannel, params.EdgeChannel},
-		expected:  params.StableChannel,
-	}, {
-		published: []params.Channel{params.EdgeChannel, params.StableChannel},
-		expected:  params.StableChannel,
-	}, {
-		published: []params.Channel{params.EdgeChannel, params.BetaChannel, params.CandidateChannel},
-		expected:  params.CandidateChannel,
-	}, {
-		clientChannel: params.StableChannel,
-		published:     []params.Channel{params.EdgeChannel, params.StableChannel},
-		expected:      params.StableChannel,
-	}, {
-		clientChannel: params.EdgeChannel,
-		published:     []params.Channel{params.StableChannel, params.EdgeChannel},
-		expected:      params.EdgeChannel,
-	}, {
-		clientChannel: params.UnpublishedChannel,
-		published:     []params.Channel{params.StableChannel},
-		expected:      params.UnpublishedChannel,
-	}, {
-		clientChannel: params.CandidateChannel,
-		published:     []params.Channel{params.EdgeChannel, params.CandidateChannel, params.StableChannel},
-		expected:      params.CandidateChannel,
-	}, {
-		expected: params.UnpublishedChannel,
-	}}
+var channelResolveTests = []struct {
+	clientChannel params.Channel
+	published     []params.Channel
+	expected      params.Channel
+}{{
+	clientChannel: params.StableChannel,
+	expected:      params.StableChannel,
+}, {
+	clientChannel: params.EdgeChannel,
+	expected:      params.EdgeChannel,
+}, {
+	clientChannel: params.UnpublishedChannel,
+	expected:      params.UnpublishedChannel,
+}, {
+	clientChannel: params.NoChannel,
+	expected:      params.UnpublishedChannel,
+}, {
+	published: []params.Channel{params.StableChannel},
+	expected:  params.StableChannel,
+}, {
+	published: []params.Channel{params.EdgeChannel},
+	expected:  params.EdgeChannel,
+}, {
+	published: []params.Channel{params.StableChannel, params.EdgeChannel},
+	expected:  params.StableChannel,
+}, {
+	published: []params.Channel{params.EdgeChannel, params.StableChannel},
+	expected:  params.StableChannel,
+}, {
+	published: []params.Channel{params.EdgeChannel, params.BetaChannel, params.CandidateChannel},
+	expected:  params.CandidateChannel,
+}, {
+	clientChannel: params.StableChannel,
+	published:     []params.Channel{params.EdgeChannel, params.StableChannel},
+	expected:      params.StableChannel,
+}, {
+	clientChannel: params.EdgeChannel,
+	published:     []params.Channel{params.StableChannel, params.EdgeChannel},
+	expected:      params.EdgeChannel,
+}, {
+	clientChannel: params.UnpublishedChannel,
+	published:     []params.Channel{params.StableChannel},
+	expected:      params.UnpublishedChannel,
+}, {
+	clientChannel: params.CandidateChannel,
+	published:     []params.Channel{params.EdgeChannel, params.CandidateChannel, params.StableChannel},
+	expected:      params.CandidateChannel,
+}, {
+	expected: params.UnpublishedChannel,
+}}
 
+func (s *charmStoreRepoSuite) TestResolveWithGloballyForcedChannel(c *gc.C) {
 	ch := TestCharms.CharmArchive(c.MkDir(), "mysql")
 	cURL := charm.MustParseURL("~who/trusty/mysql")
 
-	for i, test := range tests {
+	for i, test := range channelResolveTests {
 		c.Logf("test %d: %s/%v", i, test.clientChannel, test.published)
 
 		cURL.Revision = i
@@ -555,6 +555,33 @@ func (s *charmStoreRepoSuite) TestResolveWithChannel(c *gc.C) {
 		repo := charmrepo.NewCharmStoreFromClient(s.client.WithChannel(test.clientChannel))
 
 		_, channel, _, err := repo.ResolveWithChannel(cURL)
+		c.Assert(err, jc.ErrorIsNil)
+
+		c.Check(channel, gc.Equals, test.expected)
+	}
+}
+
+func (s *charmStoreRepoSuite) TestResolveWithPreferredChannel(c *gc.C) {
+	ch := TestCharms.CharmArchive(c.MkDir(), "mysql")
+	cURL := charm.MustParseURL("~who/trusty/mysql")
+
+	for i, test := range channelResolveTests {
+		c.Logf("test %d: %s/%v", i, test.clientChannel, test.published)
+
+		cURL.Revision = i
+		err := s.client.UploadCharmWithRevision(cURL, ch, cURL.Revision)
+		c.Assert(err, gc.IsNil)
+		s.setPublic(c, cURL)
+		if len(test.published) > 0 {
+			s.setPublic(c, cURL, test.published...)
+		} else if test.clientChannel != params.NoChannel && test.clientChannel != params.UnpublishedChannel {
+			s.setPublic(c, cURL, test.clientChannel)
+		}
+
+		// Instead of forcing a particular channel to the client, pass
+		// it as the preferred channel to the URL resolver.
+		repo := charmrepo.NewCharmStoreFromClient(s.client)
+		_, channel, _, err := repo.ResolveWithPreferredChannel(cURL, test.clientChannel)
 		c.Assert(err, jc.ErrorIsNil)
 
 		c.Check(channel, gc.Equals, test.expected)


### PR DESCRIPTION
Prior to this change, the client could enforce a particular channel for
*all* lookups. However, we the recent charm.v6 changes we are now able
to specify a per-application channel. As a result, we need a new resolve
method whose signature allows us to specify the preferred channel to
use.

If no channel is specified, the clients forced channel (if provided)
will be used as before and then the lookup code will fall back to
selecting the best (most stable) channel version based on the metadata
obtained by the store.

Note: as the `CharmStore` type methods are not included in any interface
exposed by this package this is a backwards-compatible change.