### PR TITLE
adds additional way to create a repo

### DIFF
--- a/testing/charm.go
+++ b/testing/charm.go
@@ -41,6 +41,21 @@ func NewRepo(path, defaultSeries string) *Repo {
 	return r
 }
 
+// NewRepoFromFullPath returns a new testing charm repository rooted at the given full
+// path, and not relative to the package directory, using
+// defaultSeries as the default series.
+func NewRepoFromFullPath(path, defaultSeries string) *Repo {
+	r := &Repo{
+		path:          path,
+		defaultSeries: defaultSeries,
+	}
+	_, err := os.Stat(r.path)
+	if err != nil {
+		panic(fmt.Errorf("cannot read repository found at %q: %v", r.path, err))
+	}
+	return r
+}
+
 // Repo represents a charm repository used for testing.
 type Repo struct {
 	path          string


### PR DESCRIPTION
## Why

This change enables us to create repos from any path.
With some changes to the way we test charms, we want them to reside in a tmp directory. Thus we need a way to tell which path we use instead of using the relative one.