### PR TITLE
charm testing: remove dead code

### DIFF
--- a/testing/charm.go
+++ b/testing/charm.go
@@ -41,21 +41,6 @@ func NewRepo(path, defaultSeries string) *Repo {
 	return r
 }
 
-// NewRepoFromFullPath returns a new testing charm repository rooted at the given full
-// path, and not relative to the package directory, using
-// defaultSeries as the default series.
-func NewRepoFromFullPath(path, defaultSeries string) *Repo {
-	r := &Repo{
-		path:          path,
-		defaultSeries: defaultSeries,
-	}
-	_, err := os.Stat(r.path)
-	if err != nil {
-		panic(fmt.Errorf("cannot read repository found at %q: %v", r.path, err))
-	}
-	return r
-}
-
 // Repo represents a charm repository used for testing.
 type Repo struct {
 	path          string


### PR DESCRIPTION
Initially, https://github.com/juju/charmrepo/pull/156 was put forward because we changed the way how charm vcs were defined. 
Which led to failure in some test-cases for juju, because some charms are versioned inside of juju. This led to "wrong" version expectations. 

Another later change made the `pr 156` obsolete by changing the call structure of the charms. https://github.com/juju/charm/pull/298

Therefore we can safely remove this code.