### PR TITLE
Remove client-side validation for channels when resolving charm URLs

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -186,11 +186,6 @@ func (s *CharmStore) ResolveWithPreferredChannel(ref *charm.URL, channel params.
 		channel = s.client.Channel()
 	}
 
-	// Validate requested channel.
-	if _, isValid := params.ValidChannels[channel]; !isValid && channel != params.NoChannel {
-		return nil, params.NoChannel, nil, errgo.WithCausef(nil, params.ErrNotFound, "cannot resolve URL %q: %q is not a valid channel", ref, channel)
-	}
-
 	// TODO(ericsnow) Get this directly from the API. It has high risk
 	// of getting stale. Perhaps add params.PublishedResponse.BestChannel
 	// or, less desireably, have params.PublishedResponse.Info be


### PR DESCRIPTION
PR #157  introduced client-side validation for the channel argument when resolving charm URLs. The validation was added as a nice-to-have feature that leveraged the already present [csclient/params.ValidChannels](https://github.com/juju/charmrepo/blob/v4/csclient/params/params.go#L72) map to avoid unnecessary roundtrips to the server.

Unfortunately, this addition seems to break applications that use charmrepo.v4 assuming that the validation will always be performed by the server. To address this issue, this PR removes the aforementioned validation code.

Fixes: https://bugs.launchpad.net/juju/+bug/1862091 