### PR TITLE
Expose GetFileFromArchive through the CharmStore type

### DIFF
--- a/charmstore.go
+++ b/charmstore.go
@@ -194,6 +194,20 @@ func (s *CharmStore) ResolveWithPreferredChannel(ref *charm.URL, channel params.
 	return result.Id.Id, channel, result.SupportedSeries.SupportedSeries, nil
 }
 
+// GetFileFromArchive streams the contents of the requested filename from the
+// given charm or bundle archive, returning a reader its data can be read from.
+func (s *CharmStore) GetFileFromArchive(charmURL *charm.URL, filename string) (io.ReadCloser, error) {
+	r, err := s.client.GetFileFromArchive(charmURL, filename)
+	if err != nil {
+		if errgo.Cause(err) == params.ErrNotFound {
+			return nil, params.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return r, err
+}
+
 // bestChannel determines the best channel to use for the given client
 // and published info.
 //

--- a/charmstore_test.go
+++ b/charmstore_test.go
@@ -4,13 +4,19 @@
 package charmrepo_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/juju/charm/v9"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	charmtesting "github.com/juju/charmrepo/v7/testing"
 	"github.com/juju/charmrepo/v7"
 	"github.com/juju/charmrepo/v7/csclient/params"
+	charmtesting "github.com/juju/charmrepo/v7/testing"
 )
 
 type charmStoreRepoSuite struct {
@@ -57,5 +63,57 @@ func (s *charmStoreRepoSuite) TestSortChannels(c *gc.C) {
 		c.Logf("\ntest %d: %v", i, test.input)
 		charmrepo.SortChannels(test.input)
 		c.Assert(test.input, jc.DeepEquals, test.sorted)
+	}
+}
+
+func (s *charmStoreRepoSuite) TestGetFileFromArchive(c *gc.C) {
+	specs := []struct {
+		descr               string
+		storeResCode        int
+		storeResContentType string
+		storeRes            string
+		expRes              string
+		expErr              string
+	}{
+		{
+			descr:               "store API returns not found",
+			storeResCode:        404,
+			storeResContentType: "application/json",
+			storeRes:            `{"Message":"file \"lxd-profile.yaml\" not found in the archive","Code":"not found"}`,
+			expErr:              params.ErrNotFound.Error(),
+		},
+		{
+			descr:               "store API returns the file contents",
+			storeResCode:        200,
+			storeResContentType: "text/plain",
+			storeRes:            `raw contents`,
+			expRes:              `raw contents`,
+		},
+	}
+
+	charmURL := charm.MustParseURL("cs:redis")
+	for specIdx, spec := range specs {
+		c.Logf("%d) %s", specIdx, spec.descr)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Add("Content-Type", spec.storeResContentType)
+			w.WriteHeader(spec.storeResCode)
+			_, _ = fmt.Fprint(w, spec.storeRes)
+		}))
+		defer srv.Close()
+
+		st := charmrepo.NewCharmStore(charmrepo.NewCharmStoreParams{
+			URL: srv.URL,
+		})
+
+		r, err := st.GetFileFromArchive(charmURL, "lxd-profile.yaml")
+		if spec.expErr != "" {
+			c.Assert(err, gc.ErrorMatches, spec.expErr)
+		} else {
+			got, err := ioutil.ReadAll(r)
+			_ = r.Close()
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(string(got), gc.Equals, spec.expRes)
+		}
 	}
 }

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -216,7 +216,7 @@ func (c *Client) GetArchive(id *charm.URL) (r io.ReadCloser, eid *charm.URL, has
 
 // GetFileFromArchive streams the contents of the requested filename from the
 // given charm or bundle archive, returning a reader its data can be read from.
-func (c *Client) GetFileFromArchive(id *charm.URL, filename string) (r io.ReadCloser, err error) {
+func (c *Client) GetFileFromArchive(id *charm.URL, filename string) (io.ReadCloser, error) {
 	fail := func(err error) (io.ReadCloser, error) {
 		return nil, err
 	}


### PR DESCRIPTION
This is a followup to #181 which exposes the `GetFileFromArchive` method via the `CharmStore` wrapper type that Juju uses. 

In addition, the PR also adds tests which exercise both the `CharmStore` and the underlying client implementation when `GetFileFromArchive` is invoked.